### PR TITLE
fix: Shell aliases with direnv

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,8 +17,9 @@
       # Function to create script
       mkScript = name: text: let
         script = pkgs.writeShellScriptBin name text;
-      in script;
-      
+      in
+        script;
+
       # Define your scripts/aliases
       scripts = [
         (mkScript "k" ''kubectl "$@"'')
@@ -33,19 +34,21 @@
       with pkgs; {
         devShells.default = mkShell (devEnvVars
           // {
-            nativeBuildInputs = [
-              alejandra
-              kubectl
-              python3
-              tilt
-              jq
-              k3d
-              vendir
-              ytt
-              yq-go
-              kubernetes-helm
-              opentofu
-            ] ++ scripts;
+            nativeBuildInputs =
+              [
+                alejandra
+                kubectl
+                python3
+                tilt
+                jq
+                k3d
+                vendir
+                ytt
+                yq-go
+                kubernetes-helm
+                opentofu
+              ]
+              ++ scripts;
           });
 
         formatter = alejandra;

--- a/flake.nix
+++ b/flake.nix
@@ -15,8 +15,8 @@
       pkgs = import nixpkgs {inherit system;};
 
       # Function to create script
-      mkScript = name: text: let
-        script = pkgs.writeShellScriptBin name text;
+      mkScript = alias: command: let
+        script = pkgs.writeShellScriptBin alias command;
       in
         script;
 

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,18 @@
   }:
     flake-utils.lib.eachDefaultSystem (system: let
       pkgs = import nixpkgs {inherit system;};
+
+      # Function to create script
+      mkScript = name: text: let
+        script = pkgs.writeShellScriptBin name text;
+      in script;
+      
+      # Define your scripts/aliases
+      scripts = [
+        (mkScript "k" ''kubectl "$@"'')
+        (mkScript "tf" ''tofu "$@"'')
+      ];
+
       devEnvVars = {
         KUBE_CONFIG_PATH = "~/.kube/config";
         KUBE_CTX = "k3d-k3s-default";
@@ -33,12 +45,7 @@
               yq-go
               kubernetes-helm
               opentofu
-            ];
-
-            shellHook = ''
-              alias tf=tofu
-              alias k=kubectl
-            '';
+            ] ++ scripts;
           });
 
         formatter = alejandra;


### PR DESCRIPTION
This PR fixes the issue where aliases defined in `shellHook` weren't accessible when using `direnv`. By creating executable shell scripts using `writeShellScriptBin`, we ensure the aliases work consistently across both `direnv` and `nix develop` environments.

cc https://github.com/direnv/direnv/issues/73