### PR TITLE
fix(ci): ytt template for repipe script for ci pipeline 

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -26,10 +26,6 @@ smoketest_kubeconfig: #@ data.values.staging_smoketest_kubeconfig
 #@ end
 
 groups:
-- name: galoy
-  jobs:
-  - galoy-testflight
-  - bump-galoy-in-deployments
 - name: bitcoin
   jobs:
 #@ for chart in bitcoin_charts:
@@ -44,8 +40,6 @@ groups:
 #@ end
 - name: all
   jobs:
-  - galoy-testflight
-  - bump-galoy-in-deployments
 #@ for chart in cala_charts:
   - #@ testflight_job_name(chart)
   - #@ bump_in_deployments_job_name(chart)
@@ -71,8 +65,6 @@ jobs:
 - #@ testflight_job(chart, "bitcoin")
 - #@ bump_in_deployments_job(chart)
 #@ end
-- #@ testflight_job("galoy", "galoy", galoy_chart_vars())
-- #@ bump_in_deployments_job("galoy")
 - #@ testflight_job("galoy-deps", "galoy-deps", galoy_deps_chart_vars())
 - #@ bump_in_deployments_job("galoy-deps")
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -96,7 +96,6 @@ resources:
 - #@ chart_repo_resource(chart)
 - #@ testflight_tf_resource(chart)
 #@ end
-- #@ mattermost_resource("bitcoin")
 
 - name: charts-repo
   type: git

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -54,10 +54,6 @@ groups:
   - #@ testflight_job_name(chart)
   - #@ bump_in_deployments_job_name(chart)
 #@ end
-#@ for chart in addons_charts:
-  - #@ testflight_job_name(chart)
-  - #@ bump_in_deployments_job_name(chart)
-#@ end
 - name: galoy-deps
   jobs:
   - galoy-deps-testflight

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -73,7 +73,6 @@ jobs:
 #@ end
 - #@ testflight_job("galoy", "galoy", galoy_chart_vars())
 - #@ bump_in_deployments_job("galoy")
-- #@ bump_in_deployments_job("stablesats")
 - #@ bump_in_deployments_job("galoy-deps")
 
 - name: build-chain-dl-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -89,6 +89,7 @@ resources:
 - #@ testflight_tf_resource(chart)
 #@ end
 
+- #@ mattermost_resource("bitcoin")
 - #@ chart_repo_resource("galoy-deps")
 - #@ testflight_tf_resource("galoy-deps")
 - #@ mattermost_resource("galoy-deps")

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -73,6 +73,7 @@ jobs:
 #@ end
 - #@ testflight_job("galoy", "galoy", galoy_chart_vars())
 - #@ bump_in_deployments_job("galoy")
+- #@ testflight_job("galoy-deps", "galoy-deps", galoy_deps_chart_vars())
 - #@ bump_in_deployments_job("galoy-deps")
 
 - name: build-chain-dl-image
@@ -95,6 +96,10 @@ resources:
 - #@ chart_repo_resource(chart)
 - #@ testflight_tf_resource(chart)
 #@ end
+
+- #@ chart_repo_resource("galoy-deps")
+- #@ testflight_tf_resource("galoy-deps")
+- #@ mattermost_resource("galoy-deps")
 
 - name: charts-repo
   type: git

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -27,4 +27,5 @@ staging_creds: ((staging-gcp-creds.creds_json))
 
 galoy_deps_mattermost_webhook_url: ((galoy-deps-mattermost.api_url))
 cala_mattermost_webhook_url: ((galoy-deps-mattermost.api_url))
+bitcoin_mattermost_webhook_url: ((bitcoin-mattermost.api_url))
 mattermost_username: concourse

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -25,7 +25,6 @@ staging_smoketest_kubeconfig: ((staging-smoketest.kubeconfig))
 staging_state_bucket: "galoy-staging-tf-state"
 staging_creds: ((staging-gcp-creds.creds_json))
 
-stablesats_mattermost_webhook_url: ((addons-mattermost.api_url))
 galoy_deps_mattermost_webhook_url: ((galoy-deps-mattermost.api_url))
 cala_mattermost_webhook_url: ((galoy-deps-mattermost.api_url))
 mattermost_username: concourse

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -1,12 +1,12 @@
 #@data/values
 ---
-deployments_git_uri: git@github.com:GaloyMoney/blink-deployments.git
+deployments_git_uri: git@github.com:GaloyMoney/galoy-deployments.git
 deployments_git_branch: main
 git_lnd_sidecar_bot_branch: bot-bump-lnd-sidecar-image
 git_mongo_backup_bot_branch: bot-bump-mongo-backup-image
 git_kafka_connect_bot_branch: bot-bump-kafka-connect-image
 git_org_uri: git@github.com:GaloyMoney
-git_uri: git@github.com:GaloyMoney/charts.git
+git_uri: git@github.com:GaloyMoney/galoy-charts.git
 git_branch: main
 gates_branch: cepler-gates
 github_private_key: ((github.private_key))


### PR DESCRIPTION
This pull request fixes the repipe script and makes it deployment ready for the updated config for `ci.galoy.io`. Specifically it does the following:

CI pipeline configuration updates:

* [`ci/pipeline.yml`](diffhunk://#diff-1d0bbbf28914b9bc860a34ad16f16af0a6996287a6757589f82da847185a8c68L29-L32): Removed the `galoy` job group and updated job groups to include `galoy-deps` instead. [[1]](diffhunk://#diff-1d0bbbf28914b9bc860a34ad16f16af0a6996287a6757589f82da847185a8c68L29-L32) [[2]](diffhunk://#diff-1d0bbbf28914b9bc860a34ad16f16af0a6996287a6757589f82da847185a8c68L47-L48) [[3]](diffhunk://#diff-1d0bbbf28914b9bc860a34ad16f16af0a6996287a6757589f82da847185a8c68L57-L60) [[4]](diffhunk://#diff-1d0bbbf28914b9bc860a34ad16f16af0a6996287a6757589f82da847185a8c68L78-R68)
* [`ci/pipeline.yml`](diffhunk://#diff-1d0bbbf28914b9bc860a34ad16f16af0a6996287a6757589f82da847185a8c68L103-R94): Updated resources to use `galoy-deps` instead of `bitcoin` and `galoy`.

Repository URI updates:

* [`ci/values.yml`](diffhunk://#diff-8270f696884a9ca7fb3529f0838751bf9d4e93ec7a29d4ce401ff2cfa7bb2436L3-R9): Changed `deployments_git_uri` to `git@github.com:GaloyMoney/galoy-deployments.git` and `git_uri` to `git@github.com:GaloyMoney/galoy-charts.git`.

Other value updates:

* [`ci/values.yml`](diffhunk://#diff-8270f696884a9ca7fb3529f0838751bf9d4e93ec7a29d4ce401ff2cfa7bb2436L28): Removed `stablesats_mattermost_webhook_url` and added `galoy_deps_mattermost_webhook_url`.