### PR TITLE
fix: opentelemetry config in deps values

### DIFF
--- a/charts/galoy-deps/values.yaml
+++ b/charts/galoy-deps/values.yaml
@@ -227,9 +227,8 @@ ingress-nginx:
       default: true
       watchIngressWithoutClass: true
     config:
-      enable-opentracing: true
+      enable-opentelemetry: true
       annotations-risk-level: "Critical"
-      jaeger-propagation-format: "w3c"
       log-format-upstream: "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" $request_length $request_time [$proxy_upstream_name] [$proxy_alternative_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status $req_id"
     service:
       externalTrafficPolicy: Local


### PR DESCRIPTION
`enable-opentracing` has been deprecated and only `enable-opentelemetry` is supported now.