### PR TITLE
chore: cleanup otel collector filter config

### DIFF
--- a/charts/galoy-deps/values.yaml
+++ b/charts/galoy-deps/values.yaml
@@ -122,12 +122,6 @@ opentelemetry-collector:
         passthrough: true
       filter/ottl:
         error_mode: ignore
-        traces:
-          span:
-            - 'kind.string != "Server" and IsMatch(resource.attributes["service.name"], ".*-kratos")'
-            - 'name == "query_planning" and IsMatch(resource.attributes["service.name"], ".*-router")'
-          spanevent:
-            - 'name == "" and IsMatch(resource.attributes["service.name"], ".*-router")'
         metrics:
           metric:
             - 'resource.attributes["k8s.namespace.name"] == "kube-system"'


### PR DESCRIPTION
Removing filtering rules for kratos and router traces as they have been removed from the stack