### PR TITLE
feat(galoy-deps): add galoy-agents-proxy

### DIFF
--- a/charts/galoy-deps/Chart.lock
+++ b/charts/galoy-deps/Chart.lock
@@ -11,5 +11,8 @@ dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.138.1
-digest: sha256:16b553007143cbf611311e91cb0bf710f3e15d07b445571d9b954270ac6bda74
-generated: "2025-11-06T15:23:46.612291036Z"
+- name: kubernetes-mcp-server
+  repository: oci://ghcr.io/containers/charts
+  version: 0.1.0
+digest: sha256:002ad9938f2d4f203307000f5c2c202c4c26907e36929a1d97b2bdd030ac7625
+generated: "2026-04-15T16:54:23.151688211+05:30"

--- a/charts/galoy-deps/Chart.yaml
+++ b/charts/galoy-deps/Chart.yaml
@@ -37,3 +37,7 @@ dependencies:
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     version: 0.138.1
     condition: opentelemetry-collector.enabled
+  - name: kubernetes-mcp-server
+    repository: oci://ghcr.io/containers/charts
+    version: 0.1.0
+    condition: galoyAgentsProxy.enabled

--- a/charts/galoy-deps/templates/galoy-agents-proxy-envoy-cm.yaml
+++ b/charts/galoy-deps/templates/galoy-agents-proxy-envoy-cm.yaml
@@ -1,0 +1,153 @@
+{{- if .Values.galoyAgentsProxy.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: galoy-agents-proxy-envoy
+  labels:
+    {{- include "galoy-deps.labels" . | nindent 4 }}
+    galoy-agents-proxy/component: envoy
+data:
+  envoy.yaml: |
+    admin:
+      address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: 9901
+
+    static_resources:
+      listeners:
+        - name: mcp_listener
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: 8080
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    stat_prefix: mcp_http
+                    codec_type: AUTO
+                    access_log:
+                      - name: envoy.access_loggers.stdout
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+                          log_format:
+                            json_format:
+                              ts: "%START_TIME%"
+                              method: "%REQ(:METHOD)%"
+                              path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+                              status: "%RESPONSE_CODE%"
+                              duration_ms: "%DURATION%"
+                              upstream: "%UPSTREAM_CLUSTER%"
+                              jwt_sub: "%DYNAMIC_METADATA(envoy.filters.http.jwt_authn:jwt_payload:sub)%"
+                              deployment: {{ .Values.galoyAgentsProxy.deploymentId | quote }}
+                    http_filters:
+                      - name: envoy.filters.http.jwt_authn
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
+                          providers:
+                            galoy_agents:
+                              issuer: {{ .Values.galoyAgentsProxy.jwtIssuer | quote }}
+                              audiences:
+                                - {{ .Values.galoyAgentsProxy.publicHostname | quote }}
+                              remote_jwks:
+                                http_uri:
+                                  uri: {{ .Values.galoyAgentsProxy.jwksUrl | quote }}
+                                  cluster: galoy_agents_jwks
+                                  timeout: 5s
+                                cache_duration:
+                                  seconds: 300
+                              forward: false
+                              payload_in_metadata: jwt_payload
+                          rules:
+                            - match:
+                                prefix: /
+                              requires:
+                                provider_name: galoy_agents
+                      - name: envoy.filters.http.local_ratelimit
+                        typed_config:
+                          "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+                          type_url: type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                          value:
+                            stat_prefix: mcp_rate_limit
+                            token_bucket:
+                              max_tokens: {{ mul (int .Values.galoyAgentsProxy.envoy.rateLimitRps) 10 }}
+                              tokens_per_fill: {{ .Values.galoyAgentsProxy.envoy.rateLimitRps }}
+                              fill_interval: 1s
+                            filter_enabled:
+                              runtime_key: local_rate_limit_enabled
+                              default_value:
+                                numerator: 100
+                                denominator: HUNDRED
+                            filter_enforced:
+                              runtime_key: local_rate_limit_enforced
+                              default_value:
+                                numerator: 100
+                                denominator: HUNDRED
+                      - name: envoy.filters.http.router
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                    route_config:
+                      name: mcp_routes
+                      virtual_hosts:
+                        - name: mcp_vhost
+                          domains: ["*"]
+                          routes:
+                            - match:
+                                prefix: /k8s/
+                              route:
+                                cluster: k8s_mcp
+                                prefix_rewrite: /
+                                timeout: 60s
+                            - match:
+                                prefix: /db/
+                              route:
+                                cluster: pg_mcp
+                                prefix_rewrite: /
+                                timeout: 60s
+
+      clusters:
+        - name: galoy_agents_jwks
+          type: LOGICAL_DNS
+          dns_lookup_family: V4_ONLY
+          connect_timeout: 5s
+          load_assignment:
+            cluster_name: galoy_agents_jwks
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: {{ .Values.galoyAgentsProxy.jwksHost | quote }}
+                          port_value: {{ .Values.galoyAgentsProxy.jwksPort }}
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              sni: {{ .Values.galoyAgentsProxy.jwksHost | quote }}
+        - name: k8s_mcp
+          type: STRICT_DNS
+          connect_timeout: 5s
+          load_assignment:
+            cluster_name: k8s_mcp
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: galoy-agents-proxy-k8s-mcp
+                          port_value: 8080
+        - name: pg_mcp
+          type: STRICT_DNS
+          connect_timeout: 5s
+          load_assignment:
+            cluster_name: pg_mcp
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: galoy-agents-proxy-pg-mcp
+                          port_value: 8000
+{{- end }}

--- a/charts/galoy-deps/templates/galoy-agents-proxy-envoy-deployment.yaml
+++ b/charts/galoy-deps/templates/galoy-agents-proxy-envoy-deployment.yaml
@@ -1,0 +1,72 @@
+{{- if .Values.galoyAgentsProxy.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: galoy-agents-proxy-envoy
+  labels:
+    {{- include "galoy-deps.labels" . | nindent 4 }}
+    galoy-agents-proxy/component: envoy
+spec:
+  replicas: {{ .Values.galoyAgentsProxy.envoy.replicas }}
+  selector:
+    matchLabels:
+      {{- include "galoy-deps.selectorLabels" . | nindent 6 }}
+      galoy-agents-proxy/component: envoy
+  template:
+    metadata:
+      labels:
+        {{- include "galoy-deps.labels" . | nindent 8 }}
+        galoy-agents-proxy/component: envoy
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/galoy-agents-proxy-envoy-cm.yaml") . | sha256sum }}
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: envoy
+          image: "{{ .Values.galoyAgentsProxy.envoy.image.repository }}:{{ .Values.galoyAgentsProxy.envoy.image.tag }}"
+          imagePullPolicy: {{ .Values.galoyAgentsProxy.envoy.image.pullPolicy }}
+          args:
+            - "-c"
+            - "/etc/envoy/envoy.yaml"
+            - "--log-level"
+            - "info"
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: admin
+              containerPort: 9901
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: admin
+            initialDelaySeconds: 2
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: admin
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          volumeMounts:
+            - name: envoy-config
+              mountPath: /etc/envoy
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            {{- toYaml .Values.galoyAgentsProxy.envoy.resources | nindent 12 }}
+      volumes:
+        - name: envoy-config
+          configMap:
+            name: galoy-agents-proxy-envoy
+{{- end }}

--- a/charts/galoy-deps/templates/galoy-agents-proxy-envoy-svc.yaml
+++ b/charts/galoy-deps/templates/galoy-agents-proxy-envoy-svc.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.galoyAgentsProxy.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: galoy-agents-proxy-envoy
+  labels:
+    {{- include "galoy-deps.labels" . | nindent 4 }}
+    galoy-agents-proxy/component: envoy
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "galoy-deps.selectorLabels" . | nindent 4 }}
+    galoy-agents-proxy/component: envoy
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/charts/galoy-deps/templates/galoy-agents-proxy-ingress.yaml
+++ b/charts/galoy-deps/templates/galoy-agents-proxy-ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.galoyAgentsProxy.enabled -}}
+{{- if not .Values.galoyAgentsProxy.publicHostname -}}
+{{- fail "galoyAgentsProxy.publicHostname is required when galoyAgentsProxy.enabled=true." -}}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: galoy-agents-proxy-envoy
+  labels:
+    {{- include "galoy-deps.labels" . | nindent 4 }}
+    galoy-agents-proxy/component: envoy
+  annotations:
+    cert-manager.io/cluster-issuer: {{ .Values.galoyAgentsProxy.ingress.certManagerClusterIssuer | quote }}
+    {{- if .Values.galoyAgentsProxy.galoyAgentsEgressIP }}
+    nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.galoyAgentsProxy.galoyAgentsEgressIP | quote }}
+    {{- end }}
+    {{- with .Values.galoyAgentsProxy.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.galoyAgentsProxy.ingress.className | quote }}
+  tls:
+    - hosts:
+        - {{ .Values.galoyAgentsProxy.publicHostname | quote }}
+      secretName: galoy-agents-proxy-envoy-tls
+  rules:
+    - host: {{ .Values.galoyAgentsProxy.publicHostname | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: galoy-agents-proxy-envoy
+                port:
+                  name: http
+{{- end }}

--- a/charts/galoy-deps/templates/galoy-agents-proxy-k8s-mcp-rbac.yaml
+++ b/charts/galoy-deps/templates/galoy-agents-proxy-k8s-mcp-rbac.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.galoyAgentsProxy.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: galoy-agents-proxy-k8s-mcp-read
+  labels:
+    {{- include "galoy-deps.labels" . | nindent 4 }}
+    galoy-agents-proxy/component: k8s-mcp
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - services
+      - configmaps
+      - events
+      - endpoints
+      - persistentvolumeclaims
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+      - pods/log
+    verbs: ["get", "list"]
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - statefulsets
+      - replicasets
+      - daemonsets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+      - cronjobs
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+    verbs: ["get", "list", "watch"]
+{{- range $ns := .Values.galoyAgentsProxy.kubernetesMcp.allowedNamespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: galoy-agents-proxy-k8s-mcp-read
+  namespace: {{ $ns }}
+  labels:
+    {{- include "galoy-deps.labels" $ | nindent 4 }}
+    galoy-agents-proxy/component: k8s-mcp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: galoy-agents-proxy-k8s-mcp-read
+subjects:
+  - kind: ServiceAccount
+    name: galoy-agents-proxy-k8s-mcp
+    namespace: {{ $.Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/charts/galoy-deps/templates/galoy-agents-proxy-pg-mcp-deployment.yaml
+++ b/charts/galoy-deps/templates/galoy-agents-proxy-pg-mcp-deployment.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.galoyAgentsProxy.enabled -}}
+{{- if not .Values.galoyAgentsProxy.postgresMcp.existingSecret -}}
+{{- fail "galoyAgentsProxy.postgresMcp.existingSecret is required. Provide the name of a Secret containing key DATABASE_URI." -}}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: galoy-agents-proxy-pg-mcp
+  labels:
+    {{- include "galoy-deps.labels" . | nindent 4 }}
+    galoy-agents-proxy/component: pg-mcp
+spec:
+  replicas: {{ .Values.galoyAgentsProxy.postgresMcp.replicas }}
+  selector:
+    matchLabels:
+      {{- include "galoy-deps.selectorLabels" . | nindent 6 }}
+      galoy-agents-proxy/component: pg-mcp
+  template:
+    metadata:
+      labels:
+        {{- include "galoy-deps.labels" . | nindent 8 }}
+        galoy-agents-proxy/component: pg-mcp
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: postgres-mcp-server
+          image: "{{ .Values.galoyAgentsProxy.postgresMcp.image.repository }}:{{ .Values.galoyAgentsProxy.postgresMcp.image.tag }}"
+          imagePullPolicy: {{ .Values.galoyAgentsProxy.postgresMcp.image.pullPolicy }}
+          args:
+            - "--access-mode=restricted"
+            - "--transport=sse"
+            - "--sse-host=0.0.0.0"
+            - "--sse-port=8000"
+          env:
+            - name: DATABASE_URI
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.galoyAgentsProxy.postgresMcp.existingSecret }}
+                  key: DATABASE_URI
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            {{- toYaml .Values.galoyAgentsProxy.postgresMcp.resources | nindent 12 }}
+{{- end }}

--- a/charts/galoy-deps/templates/galoy-agents-proxy-pg-mcp-svc.yaml
+++ b/charts/galoy-deps/templates/galoy-agents-proxy-pg-mcp-svc.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.galoyAgentsProxy.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: galoy-agents-proxy-pg-mcp
+  labels:
+    {{- include "galoy-deps.labels" . | nindent 4 }}
+    galoy-agents-proxy/component: pg-mcp
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "galoy-deps.selectorLabels" . | nindent 4 }}
+    galoy-agents-proxy/component: pg-mcp
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/charts/galoy-deps/values.yaml
+++ b/charts/galoy-deps/values.yaml
@@ -233,3 +233,89 @@ ingress-nginx:
         annotations:
           prometheus.io/scrape: "true"
           prometheus.io/port: "10254"
+
+galoyAgentsProxy:
+  # Master toggle. When false, nothing below is deployed and the kubernetes-mcp-server
+  # dependency is skipped via its `condition: galoyAgentsProxy.enabled`.
+  enabled: false
+
+  # Identifier for this deployment (e.g. "galoy-staging"). Used in labels/logs/JWT audience.
+  deploymentId: ""
+
+  # Public hostname exposed via the existing ingress-nginx (e.g. mcp.galoy-staging.galoy.io).
+  publicHostname: ""
+
+  # galoy-agents JWKS endpoint. Envoy fetches and caches public keys from here.
+  jwksUrl: "https://mcp.agents.galoy.io/.well-known/jwks.json"
+  jwksHost: "mcp.agents.galoy.io"
+  jwksPort: 443
+  jwtIssuer: "galoy-agents"
+
+  # Optional: restrict inbound traffic to this source IP (galoy-agents cluster egress NAT).
+  galoyAgentsEgressIP: ""
+
+  kubernetesMcp:
+    # Namespaces where the kubernetes-mcp-server SA gets a read-only RoleBinding.
+    # Kept separate from the upstream chart values so we can template RoleBindings per namespace.
+    allowedNamespaces: []
+
+  postgresMcp:
+    image:
+      repository: crystaldba/postgres-mcp
+      tag: latest
+      pullPolicy: IfNotPresent
+    # Name of an existing Secret in this namespace containing a DATABASE_URI key
+    # pointing at the read-only DB role.
+    existingSecret: ""
+    replicas: 1
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+
+  envoy:
+    image:
+      repository: envoyproxy/envoy
+      tag: v1.32-latest
+      pullPolicy: IfNotPresent
+    replicas: 2
+    rateLimitRps: 20
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+  ingress:
+    className: "nginx"
+    certManagerClusterIssuer: "letsencrypt"
+    annotations: {}
+
+# Values for the upstream kubernetes-mcp-server chart (only applied when galoyAgentsProxy.enabled=true).
+kubernetes-mcp-server:
+  fullnameOverride: "galoy-agents-proxy-k8s-mcp"
+  extraArgs:
+    - "--read-only"
+  ingress:
+    enabled: false
+  rbac:
+    # We create our own namespace-scoped RoleBindings in templates/galoy-agents-proxy/.
+    create: false
+  serviceAccount:
+    create: true
+    name: "galoy-agents-proxy-k8s-mcp"
+  service:
+    type: ClusterIP
+    port: 8080
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi


### PR DESCRIPTION
## Summary
Adds an opt-in read-only MCP gateway to galoy-deps, gated by the single flag `galoyAgentsProxy.enabled` (default false). When enabled, it lets galoy-agents reach a deployment's Kubernetes API and Postgres database through an Envoy proxy that enforces JWT authentication, with no cross-project VPC peering or bastion tunneling required.

## Architecture

```
mcp.<deployment>.galoy.io
  -> ingress-nginx (existing, public TLS via cert-manager)
  -> Envoy (JWT validation, rate limit, path routing)
    -> /k8s/* -> kubernetes-mcp-server (upstream OCI chart, --read-only)
    -> /db/*  -> postgres-mcp-server (first-party, --access-mode=restricted)
```

## What's in this PR

- `Chart.yaml`: adds `kubernetes-mcp-server` dep from `oci://ghcr.io/containers/charts`, gated by `galoyAgentsProxy.enabled`.
- `values.yaml`: adds the `galoyAgentsProxy:` config block (deploymentId, publicHostname, jwksUrl, image/resource/rate-limit tuning, allowed namespaces, existing Secret reference) + value overrides for the `kubernetes-mcp-server` subchart (disables its Ingress + RBAC; pins SA name; adds `--read-only`).
- `templates/galoy-agents-proxy/` (first-party, all gated by the flag):
  - `k8s-mcp-rbac.yaml` — one ClusterRole (read-only verbs on app-layer resources) + one RoleBinding per namespace in `allowedNamespaces`. No ClusterRoleBinding.
  - `pg-mcp-deployment.yaml` + `pg-mcp-service.yaml` — `crystaldba/postgres-mcp` in restricted mode. DB creds come from a caller-provided Secret with a `DATABASE_URI` key.
  - `envoy-configmap.yaml` — listener, `jwt_authn` with `remote_jwks` to galoy-agents, local rate limit, route table (`/k8s/*` → k8s-mcp, `/db/*` → pg-mcp), JSON access log with `sandbox_id` from the JWT `sub`.
  - `envoy-deployment.yaml` + `envoy-service.yaml`.
  - `ingress.yaml` — Ingress on `publicHostname` with cert-manager TLS + optional IP allowlist.

## Consumer contract

When a deployment flips this on in galoy-deployments (not in this PR):

\`\`\`yaml
galoyAgentsProxy:
  enabled: true
  deploymentId: "galoy-staging"
  publicHostname: "mcp.galoy-staging.galoy.io"
  kubernetesMcp:
    allowedNamespaces: ["galoy-staging-lana-bank"]
  postgresMcp:
    existingSecret: "pg-mcp-creds"   # must contain key DATABASE_URI
\`\`\`

Provisioning the `pg-mcp-creds` Secret is the caller's responsibility in galoy-deployments, using the `readonly_users` output added in GaloyMoney/galoy-infra#321.

## What I considered and rejected
- **Separate subchart under `charts/galoy-deps/charts/galoy-agents-proxy/`** — extra packaging with no real benefit; moved inline.
- **Envoy Gateway operator (`oci://docker.io/envoyproxy/gateway-helm`)** — full Gateway API control plane + CRDs per target cluster is heavy for one internal Envoy pod behind ingress-nginx. Hand-rolled Envoy ConfigMap is compact and localized.
- **An upstream chart for `crystaldba/postgres-mcp`** — none exists; the Deployment is ~30 lines.

## Test plan
- [x] `helm lint charts/galoy-deps/` clean
- [x] `helm template charts/galoy-deps/` renders correctly both disabled (default, nothing emitted) and enabled (all resources present)
- [ ] Deploy to a staging cluster and smoke-test `/k8s/*` and `/db/*` with a hand-crafted JWT before enabling more deployments.

## Related
Depends on GaloyMoney/galoy-infra#321 for the `readonly_users` DB role mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)