### PR TITLE
feat(galoy-deps): add kubernetes-mcp-server subchart

### DIFF
--- a/charts/galoy-deps/Chart.lock
+++ b/charts/galoy-deps/Chart.lock
@@ -11,5 +11,8 @@ dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.138.1
-digest: sha256:16b553007143cbf611311e91cb0bf710f3e15d07b445571d9b954270ac6bda74
-generated: "2025-11-06T15:23:46.612291036Z"
+- name: kubernetes-mcp-server
+  repository: oci://ghcr.io/containers/charts
+  version: 0.1.0
+digest: sha256:9ecdcaa33031ee0a68f5ceafa276dcc7d9a4b987999d292c31357e51e92e8334
+generated: "2026-04-20T16:07:08.424271492+05:30"

--- a/charts/galoy-deps/Chart.yaml
+++ b/charts/galoy-deps/Chart.yaml
@@ -37,3 +37,7 @@ dependencies:
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     version: 0.138.1
     condition: opentelemetry-collector.enabled
+  - name: kubernetes-mcp-server
+    repository: oci://ghcr.io/containers/charts
+    version: 0.1.0
+    condition: kubernetesMcp.enabled

--- a/charts/galoy-deps/templates/kubernetes-mcp-rbac.yaml
+++ b/charts/galoy-deps/templates/kubernetes-mcp-rbac.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.kubernetesMcp.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubernetes-mcp-server-read
+  labels:
+    {{- include "galoy-deps.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kubernetes-mcp-server
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - services
+      - configmaps
+      - events
+      - endpoints
+      - persistentvolumeclaims
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+      - pods/log
+    verbs: ["get", "list"]
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - statefulsets
+      - replicasets
+      - daemonsets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+      - cronjobs
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+    verbs: ["get", "list", "watch"]
+{{- range $ns := .Values.kubernetesMcp.allowedNamespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubernetes-mcp-server-read
+  namespace: {{ $ns }}
+  labels:
+    {{- include "galoy-deps.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: kubernetes-mcp-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubernetes-mcp-server-read
+subjects:
+  - kind: ServiceAccount
+    name: kubernetes-mcp-server
+    namespace: {{ $.Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/charts/galoy-deps/values.yaml
+++ b/charts/galoy-deps/values.yaml
@@ -233,3 +233,41 @@ ingress-nginx:
         annotations:
           prometheus.io/scrape: "true"
           prometheus.io/port: "10254"
+
+# Read-only Kubernetes MCP server. When enabled, deploys the upstream
+# kubernetes-mcp-server chart with `--read-only` and templates one
+# RoleBinding per namespace in `allowedNamespaces`. No ClusterRoleBinding
+# is created — access is scoped to the listed namespaces only.
+kubernetesMcp:
+  enabled: false
+  # Namespaces where the MCP server's ServiceAccount gets a read-only
+  # RoleBinding. Empty = the ClusterRole is created but bound nowhere.
+  allowedNamespaces: []
+
+# Values passed through to the upstream kubernetes-mcp-server chart.
+# Only applied when kubernetesMcp.enabled=true (via the condition on the
+# dependency in Chart.yaml).
+kubernetes-mcp-server:
+  fullnameOverride: "kubernetes-mcp-server"
+  extraArgs:
+    - "--read-only"
+  ingress:
+    enabled: false
+  rbac:
+    # We template our own namespace-scoped RoleBindings in
+    # templates/kubernetes-mcp-rbac.yaml, so the subchart must not create
+    # a ClusterRoleBinding.
+    create: false
+  serviceAccount:
+    create: true
+    name: "kubernetes-mcp-server"
+  service:
+    type: ClusterIP
+    port: 8080
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi


### PR DESCRIPTION
## Summary
Opt-in read-only Kubernetes MCP server in `galoy-deps`, gated by the new `kubernetesMcp.enabled` flag (default false).

Split from #250 — standalone so it can be deployed without the tunnel-connector (useful for local debugging) and reviewed independently.

## What this adds

- `kubernetes-mcp-server` OCI chart dep (`ghcr.io/containers/charts`, v0.1.0), gated by `condition: kubernetesMcp.enabled`
- Subchart value overrides:
  - `--read-only` via `extraArgs`
  - `ingress.enabled=false` (no public exposure — the tunnel-connector will reach it on its ClusterIP)
  - `rbac.create=false` — we template our own namespace-scoped bindings
- First-party template `templates/kubernetes-mcp-rbac.yaml`:
  - A `ClusterRole` (`kubernetes-mcp-server-read`) with `get/list/watch` on app-layer resources (pods, pods/log, services, configmaps, events, endpoints, PVCs, deployments, statefulsets, replicasets, daemonsets, jobs, cronjobs, ingresses)
  - One `RoleBinding` per entry in `kubernetesMcp.allowedNamespaces` — no `ClusterRoleBinding`, access scoped to the explicit allow-list

## Consumer contract

```yaml
kubernetesMcp:
  enabled: true
  allowedNamespaces:
    - galoy-staging-lana-bank
```

## What's next (separate PRs)

- tunnel-connector Deployment in galoy-deps that reaches this service
- postgres-mcp in the lana-bank chart (DB URL is lana-specific, doesn't belong here)

## Test plan

- [x] `helm dep update` pulls the OCI chart cleanly
- [x] `helm lint` clean
- [x] `helm template` with flag off → no kubernetes-mcp-server resources emitted
- [x] `helm template` with flag on + 2 allowedNamespaces → subchart resources + ClusterRole + 2 RoleBindings (one per namespace)
- [ ] Deploy to a staging cluster and smoke-test `kubectl get pods` via the in-cluster ClusterIP service

🤖 Generated with [Claude Code](https://claude.com/claude-code)