### PR TITLE
feat(galoy-deps): add tunnel-connector Deployment

### DIFF
--- a/charts/galoy-deps/templates/_helpers.tpl
+++ b/charts/galoy-deps/templates/_helpers.tpl
@@ -60,3 +60,16 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Render tunnelConnector.upstreams as a TUNNEL_UPSTREAMS env value:
+  "name1=url1,name2=url2,..."
+Used by templates/tunnel-connector-deployment.yaml.
+*/}}
+{{- define "galoy-deps.tunnelConnector.upstreamsEnv" -}}
+{{- $parts := list -}}
+{{- range .Values.tunnelConnector.upstreams -}}
+{{- $parts = append $parts (printf "%s=%s" .name .url) -}}
+{{- end -}}
+{{- join "," $parts -}}
+{{- end }}

--- a/charts/galoy-deps/templates/tunnel-connector-deployment.yaml
+++ b/charts/galoy-deps/templates/tunnel-connector-deployment.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.tunnelConnector.enabled -}}
+{{- if not .Values.tunnelConnector.serverUrl }}
+{{- fail "tunnelConnector.serverUrl is required when tunnelConnector.enabled=true" }}
+{{- end }}
+{{- if not .Values.tunnelConnector.deploymentId }}
+{{- fail "tunnelConnector.deploymentId is required when tunnelConnector.enabled=true" }}
+{{- end }}
+{{- if not .Values.tunnelConnector.existingTokenSecret }}
+{{- fail "tunnelConnector.existingTokenSecret is required when tunnelConnector.enabled=true" }}
+{{- end }}
+{{- if not .Values.tunnelConnector.upstreams }}
+{{- fail "tunnelConnector.upstreams must list at least one {name, url} entry" }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tunnel-connector
+  labels:
+    {{- include "galoy-deps.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tunnel-connector
+spec:
+  replicas: {{ .Values.tunnelConnector.replicas }}
+  selector:
+    matchLabels:
+      {{- include "galoy-deps.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: tunnel-connector
+  template:
+    metadata:
+      labels:
+        {{- include "galoy-deps.labels" . | nindent 8 }}
+        app.kubernetes.io/component: tunnel-connector
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: connector
+          image: "{{ .Values.tunnelConnector.image.repository }}:{{ .Values.tunnelConnector.image.tag }}"
+          imagePullPolicy: {{ .Values.tunnelConnector.image.pullPolicy }}
+          env:
+            - name: TUNNEL_SERVER_URL
+              value: {{ .Values.tunnelConnector.serverUrl | quote }}
+            - name: TUNNEL_DEPLOYMENT_ID
+              value: {{ .Values.tunnelConnector.deploymentId | quote }}
+            - name: TUNNEL_UPSTREAMS
+              value: {{ include "galoy-deps.tunnelConnector.upstreamsEnv" . | quote }}
+            - name: TUNNEL_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.tunnelConnector.existingTokenSecret }}
+                  key: token
+            - name: RUST_LOG
+              value: "info"
+          resources:
+            {{- toYaml .Values.tunnelConnector.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+{{- end }}

--- a/charts/galoy-deps/values.yaml
+++ b/charts/galoy-deps/values.yaml
@@ -233,3 +233,42 @@ ingress-nginx:
         annotations:
           prometheus.io/scrape: "true"
           prometheus.io/port: "10254"
+
+# Tunnel connector. Dials out over WebSocket to galoy-agents and relays
+# MCP tool calls against in-cluster MCP servers (kubernetes-mcp,
+# postgres-mcp, lana admin MCP, ...). No inbound network exposure.
+tunnelConnector:
+  enabled: false
+  image:
+    repository: us.gcr.io/galoyorg/tunnel-connector
+    # Placeholder until drua publishes a real tag — do not flip
+    # `enabled: true` until this is a concrete digest.
+    tag: edge
+    pullPolicy: IfNotPresent
+  # `wss://mcp.agents.galoy.io/tunnel/ws` in staging.
+  serverUrl: ""
+  # Stable identifier — appears in the galoy-agents tool catalog as a
+  # prefix on every tool name (e.g. `galoy_staging_kubernetes_list_pods`).
+  deploymentId: ""
+  # Name of an existing Secret in this namespace carrying a `token` key.
+  # The operator provisions this token via galoy-agents' mcp-creds UI.
+  existingTokenSecret: ""
+  # Upstream MCP servers the connector will relay to. Each entry becomes
+  # part of TUNNEL_UPSTREAMS in `name=url,name=url` form. The connector
+  # fetches the tool catalog from each at startup.
+  #
+  # Example:
+  #   upstreams:
+  #     - name: kubernetes
+  #       url: http://kubernetes-mcp-server:8080/mcp
+  #     - name: postgres
+  #       url: http://lana-bank-postgres-mcp:8000/mcp
+  upstreams: []
+  replicas: 1
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi


### PR DESCRIPTION
## Summary
Opt-in tunnel connector that dials out over WebSocket to galoy-agents and relays MCP tool calls against in-cluster MCP servers. Second of two PRs splitting the work in the now-closed #250.

No inbound network exposure — purely outbound from the target cluster.

## What this adds

- `templates/tunnel-connector-deployment.yaml` — Deployment running the connector binary with restricted pod-security posture (non-root, read-only FS, no privilege escalation, all caps dropped, SA token disabled)
- `_helpers.tpl` — `galoy-deps.tunnelConnector.upstreamsEnv` renders `upstreams: [{name, url}]` into the `TUNNEL_UPSTREAMS` env var's `name=url,name=url,…` format
- `values.yaml` — new `tunnelConnector:` block

## Fail-fast validation

All four required operator inputs are validated at render time — misconfig errors come out of `helm template`, not from `CrashLoopBackOff`:

- `tunnelConnector.serverUrl`
- `tunnelConnector.deploymentId`
- `tunnelConnector.existingTokenSecret`
- `tunnelConnector.upstreams` (non-empty)

## Image placeholder

`us.gcr.io/galoyorg/tunnel-connector:edge` is a placeholder. The drua side needs an image-build pipeline (follow-up after drua#127 merges). **Do not flip `tunnelConnector.enabled=true` anywhere until a concrete digest is published.** The chart change is mergeable on its own; deployment is gated on the image existing.

## Consumer contract

```yaml
tunnelConnector:
  enabled: true
  serverUrl: wss://mcp.agents.galoy.io/tunnel/ws
  deploymentId: galoy-staging
  existingTokenSecret: tunnel-connector-creds  # key: token
  upstreams:
    - name: kubernetes
      url: http://kubernetes-mcp-server:8080/mcp   # from #251
    - name: postgres
      url: http://lana-bank-postgres-mcp:8000/mcp  # from lana-bank PR
```

The `upstreams` list is intentionally not auto-populated from `kubernetesMcp.enabled` — keeping the two features decoupled lets them land and operate independently, and each deployment gets to decide exactly what it exposes.

## Test plan

- [x] `helm template` with flag off → no connector resources emitted
- [x] `helm template` with flag on + valid inputs → Deployment renders, `TUNNEL_UPSTREAMS` env joins correctly
- [x] `helm template` with flag on + missing `serverUrl` → fail-gate fires with a clear message
- [x] `helm lint` clean
- [ ] End-to-end: once drua#127 lands + image is published, wire against a staging cluster and verify tools appear in galoy-agents catalog

## Related

- #251 — sibling k8s-mcp PR (also split from #250)
- GaloyMoney/drua#127 — the tunnel server + connector protocol + binary source
- lana-bank PR (incoming) — postgres-mcp (DB URL lives there, not here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)