### PR TITLE
feat(galoy-deps): kubernetes-mcp clusterWide RBAC mode

### DIFF
--- a/charts/galoy-deps/templates/kubernetes-mcp-rbac.yaml
+++ b/charts/galoy-deps/templates/kubernetes-mcp-rbac.yaml
@@ -36,6 +36,24 @@ rules:
     resources:
       - ingresses
     verbs: ["get", "list", "watch"]
+{{- if .Values.kubernetesMcp.clusterWide }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-mcp-server-read
+  labels:
+    {{- include "galoy-deps.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kubernetes-mcp-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubernetes-mcp-server-read
+subjects:
+  - kind: ServiceAccount
+    name: kubernetes-mcp-server
+    namespace: {{ .Release.Namespace }}
+{{- else }}
 {{- range $ns := .Values.kubernetesMcp.allowedNamespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -54,5 +72,6 @@ subjects:
   - kind: ServiceAccount
     name: kubernetes-mcp-server
     namespace: {{ $.Release.Namespace }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/galoy-deps/values.yaml
+++ b/charts/galoy-deps/values.yaml
@@ -235,13 +235,14 @@ ingress-nginx:
           prometheus.io/port: "10254"
 
 # Read-only Kubernetes MCP server. When enabled, deploys the upstream
-# kubernetes-mcp-server chart with `--read-only` and templates one
-# RoleBinding per namespace in `allowedNamespaces`. No ClusterRoleBinding
-# is created — access is scoped to the listed namespaces only.
+# kubernetes-mcp-server chart with `--read-only`. Set `clusterWide: true`
+# to grant access across the entire cluster (ClusterRoleBinding), or list
+# specific namespaces in `allowedNamespaces` for namespace-scoped
+# RoleBindings. The two are mutually exclusive: clusterWide takes
+# precedence when true.
 kubernetesMcp:
   enabled: false
-  # Namespaces where the MCP server's ServiceAccount gets a read-only
-  # RoleBinding. Empty = the ClusterRole is created but bound nowhere.
+  clusterWide: false
   allowedNamespaces: []
 
 # Values passed through to the upstream kubernetes-mcp-server chart.


### PR DESCRIPTION
## Summary
- Adds `kubernetesMcp.clusterWide` (default `false`). When `true`, renders a `ClusterRoleBinding` instead of per-namespace `RoleBindings`, granting the read-only role across the entire cluster.
- Existing `allowedNamespaces` behaviour is unchanged when `clusterWide=false`.

## Test plan
- [x] `helm template` with `clusterWide=true` renders a single `ClusterRoleBinding`
- [x] `helm template` with `allowedNamespaces=[a,b]` (and `clusterWide=false`) still renders one `RoleBinding` per namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)