### PR TITLE
ci: auto-bump tunnel-connector image digest in galoy-deps

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -3,6 +3,7 @@
 #@   "testflight_job",
 #@   "bump_in_deployments_job",
 #@   "chart_repo_resource",
+#@   "task_image_config",
 #@   "testflight_tf_resource")
 
 groups:
@@ -10,10 +11,56 @@ groups:
   jobs:
   - galoy-deps-testflight
   - bump-galoy-deps-in-deployments
+  - bump-tunnel-connector-image
 
 jobs:
 - #@ testflight_job("galoy-deps", "galoy-deps")
 - #@ bump_in_deployments_job("galoy-deps")
+
+#! Watches the `tunnel-connector:edge` image pushed by drua CI and opens
+#! (or force-updates) a PR pinning the latest digest in
+#! `charts/galoy-deps/values.yaml`. Using a digest instead of the mutable
+#! `:edge` tag means a drua CI push doesn't silently roll any deployed
+#! connector — the bump is an auditable PR instead.
+- name: bump-tunnel-connector-image
+  plan:
+  - in_parallel:
+    - get: tunnel-connector-image
+      trigger: true
+      params: { skip_download: true }
+    - get: charts-repo
+    - get: pipeline-tasks
+  - task: update-digest
+    config:
+      platform: linux
+      image_resource: #@ task_image_config()
+      inputs:
+      - name: tunnel-connector-image
+      - name: charts-repo
+      - name: pipeline-tasks
+      outputs:
+      - name: charts-repo
+      run:
+        path: pipeline-tasks/ci/tasks/bump-tunnel-connector-image.sh
+  - put: bump-tunnel-connector-image-bot-branch
+    params:
+      repository: charts-repo
+      branch: bump-tunnel-connector-image-bot-branch
+      force: true
+  - task: open-bump-pr
+    config:
+      platform: linux
+      image_resource: #@ task_image_config()
+      params:
+        GH_APP_ID: #@ data.values.github_app_id
+        GH_APP_PRIVATE_KEY: #@ data.values.github_app_private_key
+        BRANCH: #@ data.values.git_branch
+        BOT_BRANCH: bump-tunnel-connector-image-bot-branch
+      inputs:
+      - name: pipeline-tasks
+      - name: charts-repo
+      run:
+        path: pipeline-tasks/ci/tasks/open-bump-tunnel-connector-image-pr.sh
 
 resources:
 - #@ chart_repo_resource("galoy-deps")
@@ -39,6 +86,21 @@ resources:
   source:
     uri: #@ data.values.deployments_git_uri
     branch: #@ data.values.deployments_git_branch
+    private_key: #@ data.values.github_private_key
+
+- name: tunnel-connector-image
+  type: registry-image
+  source:
+    repository: #@ data.values.docker_registry + "/tunnel-connector"
+    tag: edge
+    username: #@ data.values.gar_registry_user
+    password: #@ data.values.gar_registry_password
+
+- name: bump-tunnel-connector-image-bot-branch
+  type: git
+  source:
+    uri: #@ data.values.git_uri
+    branch: bump-tunnel-connector-image-bot-branch
     private_key: #@ data.values.github_private_key
 
 resource_types:

--- a/ci/tasks/bump-tunnel-connector-image.sh
+++ b/ci/tasks/bump-tunnel-connector-image.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Bumps `tunnelConnector.image.digest` in `charts/galoy-deps/values.yaml`
+# to the digest of the currently-latest `tunnel-connector:edge` image, as
+# fetched by the `tunnel-connector-image` registry resource. Pairs with
+# `open-bump-tunnel-connector-image-pr.sh`, which opens/updates the PR.
+#
+# No-op (no commit) when the digest in values.yaml already matches —
+# otherwise Concourse would churn a PR on every resource poll.
+
+set -eu
+
+DIGEST=$(cat tunnel-connector-image/digest)
+VALUES="charts-repo/charts/galoy-deps/values.yaml"
+
+CURRENT=$(yq '.tunnelConnector.image.digest' "$VALUES")
+if [[ "$CURRENT" == "$DIGEST" ]]; then
+  echo "tunnel-connector digest already at $DIGEST — nothing to do"
+  exit 0
+fi
+
+yq -i ".tunnelConnector.image.digest = \"${DIGEST}\"" "$VALUES"
+
+if [[ -z $(git config --global user.email) ]]; then
+  git config --global user.email "bot@galoy.io"
+fi
+if [[ -z $(git config --global user.name) ]]; then
+  git config --global user.name "CI Bot"
+fi
+
+cd charts-repo
+git add -A
+git status
+
+if ! git diff --cached --exit-code; then
+  git commit -m "chore(deps): bump tunnel-connector image digest to ${DIGEST}"
+fi

--- a/ci/tasks/open-bump-tunnel-connector-image-pr.sh
+++ b/ci/tasks/open-bump-tunnel-connector-image-pr.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Opens (or re-opens) a PR for the bot-branch that
+# `bump-tunnel-connector-image.sh` force-pushes to. Closes any existing
+# PR on that branch first so the body reflects the current digest — the
+# branch is continuously force-pushed, and we want a single, always-current
+# open PR rather than a list of stale superseded ones.
+
+set -eu
+
+pushd charts-repo > /dev/null
+
+DIGEST=$(yq '.tunnelConnector.image.digest' charts/galoy-deps/values.yaml)
+
+cat <<EOF > ../body.md
+Auto-bump of \`tunnelConnector.image.digest\` in \`charts/galoy-deps/values.yaml\` to the latest \`tunnel-connector:edge\` digest published by drua CI:
+
+\`\`\`
+${DIGEST}
+\`\`\`
+
+This pins galoy-deps to a specific image content hash, so a subsequent CI push to drua can't silently roll a running connector. The bot force-pushes the bot branch on every new drua image, so this PR is always current — merge when convenient.
+EOF
+
+export GH_TOKEN="$(ghtoken generate -b "${GH_APP_PRIVATE_KEY}" -i "${GH_APP_ID}" | jq -r '.token')"
+
+gh pr close "${BOT_BRANCH}" || true
+gh pr create \
+  --title "chore(deps): bump tunnel-connector image digest" \
+  --body-file ../body.md \
+  --base "${BRANCH}" \
+  --head "${BOT_BRANCH}" \
+  --label galoybot \
+  --label tunnel-connector
+
+popd > /dev/null


### PR DESCRIPTION
## Summary

Adds a Concourse job that watches the `tunnel-connector:edge` image published by drua CI and, on every new digest, opens (or force-updates) a PR pinning `.tunnelConnector.image.digest` in `charts/galoy-deps/values.yaml`.

## Why digest instead of `:edge`

`:edge` is mutable. Without this, each drua CI push would silently roll every running `tunnel-connector` pod on the next kubelet restart or pod reschedule. That's fine for dev, not for staging or prod.

Pinning to the digest makes every bump an auditable PR. Humans decide when to merge; the merge is what actually rolls the connectors. Same posture we already have for other components.

## Mechanism

Mirrors the existing helm-dep bump pattern in this repo (`ci/tasks/update-helm-dep.sh` + `open-update-helm-deps-pr.sh`):

1. New `tunnel-connector-image` registry-image resource polls `us.gcr.io/galoyorg/tunnel-connector:edge`.
2. New `bump-tunnel-connector-image` job triggers on digest change, runs `yq` to write the new digest into `values.yaml`, force-pushes a bot branch.
3. `open-bump-pr` task closes any existing bot PR and creates a fresh one with the current digest in the body (same close+create dance the helm-deps bump already uses).

Two new task scripts:

- `ci/tasks/bump-tunnel-connector-image.sh` — no-ops if the digest in values.yaml already matches (so the bot branch doesn't churn when the pipeline just polls and finds no change).
- `ci/tasks/open-bump-tunnel-connector-image-pr.sh` — close-then-create the bot PR.

## Prerequisite

**Needs #259 to land first.** That PR adds the `tunnelConnector.image.digest` field this job writes into, plus the template logic that prefers digest over `tag`. Without #259, the bump job would either fail (no `tunnelConnector.image` struct to modify) or silently create a dangling key that the template ignores.

## Verified

- `ytt -f ci/pipeline.yml -f ci/pipeline-fragments.lib.yml -f ci/values.yml` renders cleanly.
- Generated job, task, and two new resources look correct.
- Script logic trivially mirrors the existing helm-deps bump flow.

## Test plan

- [x] ytt renders cleanly
- [ ] Merge #259 first
- [ ] Repipe galoy-charts, confirm `bump-tunnel-connector-image` appears in the galoy-deps group
- [ ] Trigger a drua CI push (or wait for one) and confirm the bot opens a PR with the current digest
- [ ] Merge the bot PR, confirm the rollout actually happens in staging (connector pod restarts with new digest)

## Related

- Companion: GaloyMoney/galoy-charts#259 (adds the `digest` field this job writes into)
- Upstream: GaloyMoney/drua#127 (merged — publishes `tunnel-connector:edge`)
- Parent: GaloyMoney/volcano-wip#729

🤖 Generated with [Claude Code](https://claude.com/claude-code)