### PR TITLE
feat(galoy-deps): mount private-key PEM instead of token for tunnel-connector

### DIFF
--- a/charts/galoy-deps/templates/tunnel-connector-deployment.yaml
+++ b/charts/galoy-deps/templates/tunnel-connector-deployment.yaml
@@ -5,8 +5,8 @@
 {{- if not .Values.tunnelConnector.deploymentId }}
 {{- fail "tunnelConnector.deploymentId is required when tunnelConnector.enabled=true" }}
 {{- end }}
-{{- if not .Values.tunnelConnector.existingTokenSecret }}
-{{- fail "tunnelConnector.existingTokenSecret is required when tunnelConnector.enabled=true" }}
+{{- if not .Values.tunnelConnector.existingPrivateKeySecret }}
+{{- fail "tunnelConnector.existingPrivateKeySecret is required when tunnelConnector.enabled=true" }}
 {{- end }}
 {{- if not .Values.tunnelConnector.upstreams }}
 {{- fail "tunnelConnector.upstreams must list at least one {name, url} entry" }}
@@ -50,13 +50,21 @@ spec:
               value: {{ .Values.tunnelConnector.deploymentId | quote }}
             - name: TUNNEL_UPSTREAMS
               value: {{ include "galoy-deps.tunnelConnector.upstreamsEnv" . | quote }}
-            - name: TUNNEL_AUTH_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.tunnelConnector.existingTokenSecret }}
-                  key: token
+            - name: TUNNEL_PRIVATE_KEY_FILE
+              value: /var/run/secrets/tunnel-connector/private_key.pem
             - name: RUST_LOG
               value: "info"
+          volumeMounts:
+            - name: private-key
+              mountPath: /var/run/secrets/tunnel-connector
+              readOnly: true
           resources:
             {{- toYaml .Values.tunnelConnector.resources | nindent 12 }}
+      volumes:
+        - name: private-key
+          secret:
+            secretName: {{ .Values.tunnelConnector.existingPrivateKeySecret }}
+            items:
+              - key: private_key.pem
+                path: private_key.pem
 {{- end }}

--- a/charts/galoy-deps/values.yaml
+++ b/charts/galoy-deps/values.yaml
@@ -359,11 +359,13 @@ tunnelConnector:
   # the key drua's TunnelRegistry uses to enforce single-live-tunnel
   # per deployment, so keep it distinct per release.
   deploymentId: ""
-  # Name of an existing Secret in this namespace carrying a `token` key.
-  # The operator provisions this via drua's mcp-creds UI with
-  # `tunnel_deployment_id` set to match `deploymentId` above; drua will
-  # refuse registration if the scope doesn't match.
-  existingTokenSecret: ""
+  # Name of an existing Secret in this namespace carrying a PKCS#8 PEM
+  # Ed25519 private key under the `private_key.pem` key. Mounted read-only
+  # at /var/run/secrets/tunnel-connector/private_key.pem; the connector
+  # signs the handshake with it. The matching public key lives in drua's
+  # `server.tunnel.deployments.<deploymentId>` config — drua rejects the
+  # upgrade if the signature doesn't verify.
+  existingPrivateKeySecret: ""
   # Upstream MCP servers the connector will relay to. Each entry becomes
   # part of TUNNEL_UPSTREAMS in `name=url,name=url` form. The connector
   # fetches the tool catalog from each at startup; if any upstream is


### PR DESCRIPTION
## Summary

Drua's `/tunnel/ws` is moving from Bearer-token auth to an Ed25519 handshake signed on every connect (GaloyMoney/drua#186). The chart needs to match: provide the signing key as a file, not an env var.

## Changes

**`values.yaml`**

- `existingTokenSecret` → `existingPrivateKeySecret`.
- Secret must carry a PKCS#8 PEM Ed25519 private key under the `private_key.pem` key. Terraform-generated in galoy-org-infra and distributed per-env through the existing Vault → `galoy_deps` bundle path (see GaloyMoney/galoy-org-infra#90).

**`templates/tunnel-connector-deployment.yaml`**

- Drop `TUNNEL_AUTH_TOKEN` env-from-secret.
- Read-only volume mount at `/var/run/secrets/tunnel-connector/private_key.pem` projecting just the `private_key.pem` key.
- `TUNNEL_PRIVATE_KEY_FILE=<mount path>` env so the connector binary picks it up (see `images/tunnel-connector/src/main.rs` in drua#186).

## Verified

- `helm template` with `enabled=true` and minimal required values emits the expected `env`, `volumeMounts`, and `volumes` blocks.
- Default-off (`tunnelConnector.enabled=false`) produces zero tunnel-connector resources.
- Missing required field (`existingPrivateKeySecret`, etc.) still fails fast with a clear error.

## Related

- drua: GaloyMoney/drua#186 (keypair handshake, PEM public keys in config)
- galoy-org-infra: GaloyMoney/galoy-org-infra#90 (generates the keypair, distributes via Vault)
- galoy-deployments: GaloyMoney/galoy-deployments#2358 (needs rewrite to consume `jsondecode(var.secrets).tunnel_connector_private_key_pem` and render the Secret under this new field name)
- parent: GaloyMoney/volcano-wip#729

🤖 Generated with [Claude Code](https://claude.com/claude-code)