### PR TITLE
fix(ci): skip PR creation when helm chart is already up to date

### DIFF
--- a/ci/tasks/open-update-helm-deps-pr.sh
+++ b/ci/tasks/open-update-helm-deps-pr.sh
@@ -4,6 +4,12 @@ set -eu
 
 pushd charts-repo
 
+# If bot branch has no commits ahead of base, chart is already up to date
+if [ -z "$(git log ${BRANCH}..HEAD --oneline)" ]; then
+  echo "No changes to propose — chart already up to date."
+  exit 0
+fi
+
 cat <<EOF >> ../body.md
 This PR updates Helm Chart Dependencies.
 EOF


### PR DESCRIPTION
## Summary

`bump-*-chart` CI jobs fail whenever the upstream helm chart hasn't changed. `update-helm-dep.sh` correctly no-ops (skips committing), but `open-update-helm-deps-pr.sh` unconditionally runs `gh pr create`. GitHub rejects it: "No commits between main and \<bot-branch\>".

Fix: early-exit when the bot branch has no commits ahead of main.

### Evidence

**`bump-kube-monkey-galoy-deps-chart`** — 1/1 builds failed (never succeeded):
- [Build #1](https://ci.galoy.io/teams/dev/pipelines/helm-charts/jobs/bump-kube-monkey-galoy-deps-chart/builds/1) (ID 5389271) — `pull request create failed: GraphQL: No commits between main and helm-kube-monkey-galoy-deps-bot-branch`

For comparison, [bump-cert-manager build #1](https://ci.galoy.io/teams/dev/pipelines/helm-charts/jobs/bump-cert-manager-galoy-deps-chart/builds/1) (ID 5389268) succeeded — it had a real chart diff to propose.

Same fix applied to lana-bank in [GaloyMoney/lana-bank#5352](https://github.com/GaloyMoney/lana-bank/pull/5352) (affects `bump-gotenberg-chart`).

## Test plan

- [ ] Trigger `bump-kube-monkey-galoy-deps-chart` — should exit 0 instead of failing
- [ ] Trigger a bump job with an actual version change — should still create a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)