### PR TITLE
feat(galoy-deps): shorten tunnel kubernetes upstream name to k8s

### DIFF
--- a/charts/galoy-deps/values.yaml
+++ b/charts/galoy-deps/values.yaml
@@ -355,7 +355,7 @@ tunnelConnector:
   # in staging. Must accept a WS upgrade at `/tunnel/ws`.
   serverUrl: ""
   # Stable identifier — appears in drua's tool catalog as a prefix on
-  # every tool name (e.g. `galoy_staging_kubernetes_list_pods`). Also
+  # every tool name (e.g. `galoy_staging_k8s_list_pods`). Also
   # the key drua's TunnelRegistry uses to enforce single-live-tunnel
   # per deployment, so keep it distinct per release.
   deploymentId: ""
@@ -377,7 +377,7 @@ tunnelConnector:
   # this list in full — helm `upstreams:` is an atomic replacement, not
   # a merge.
   upstreams:
-    - name: kubernetes
+    - name: k8s
       url: http://kubernetes-mcp-server:8080/mcp
   replicas: 1
   resources:


### PR DESCRIPTION
## Summary
- Rename the default tunnel-connector upstream from `kubernetes` → `k8s` so drua advertises k8s tools as `galoy_staging_k8s_*` instead of `galoy_staging_kubernetes_*`.
- ~4 tokens shaved off every k8s tool name in the catalog. Routing is unaffected: the in-cluster Service name (`kubernetes-mcp-server`) is the URL target, not the upstream key the connector publishes.
- Updated the `deploymentId` example comment to match the new prefix shape.

## Test plan
- [ ] Render `galoy-deps` chart and confirm the connector Pod's `TUNNEL_UPSTREAMS` env contains `k8s=http://kubernetes-mcp-server:8080/mcp`.
- [ ] Deploy to staging; confirm drua's tool catalog lists `galoy_staging_k8s_*` tools (not `galoy_staging_kubernetes_*`).
- [ ] Any deployment-level overrides in galoy-deployments that pin `name: kubernetes` need a matching rename to take effect — sweep before merging staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)