### PR TITLE
chore(galoy-deps): add Gotenberg dependency

### DIFF
--- a/charts/galoy-deps/Chart.lock
+++ b/charts/galoy-deps/Chart.lock
@@ -11,8 +11,11 @@ dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.138.1
+- name: gotenberg
+  repository: https://maikumori.github.io/helm-charts/
+  version: 1.21.0
 - name: kubernetes-mcp-server
   repository: oci://ghcr.io/containers/charts
   version: 0.1.0
-digest: sha256:1da638cb613df533798fe15965205fb8d475b7c69de3d588e7164a2d3c4497e8
-generated: "2026-04-22T10:32:27.15288512Z"
+digest: sha256:6eb495995a055a0dea1eeae517fc68422336a0b99a292b278ee3ce868820b8f3
+generated: "2026-05-06T15:37:29.263124-04:00"

--- a/charts/galoy-deps/Chart.yaml
+++ b/charts/galoy-deps/Chart.yaml
@@ -37,6 +37,10 @@ dependencies:
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     version: 0.138.1
     condition: opentelemetry-collector.enabled
+  - name: gotenberg
+    repository: https://maikumori.github.io/helm-charts/
+    version: 1.21.0
+    condition: gotenberg.enabled
   - name: kubernetes-mcp-server
     repository: oci://ghcr.io/containers/charts
     version: 0.1.0

--- a/charts/galoy-deps/values.yaml
+++ b/charts/galoy-deps/values.yaml
@@ -230,6 +230,12 @@ ingress-nginx:
         annotations:
           prometheus.io/scrape: "true"
           prometheus.io/port: "10254"
+gotenberg:
+  enabled: false
+  fullnameOverride: gotenberg
+  replicaCount: 1
+  service:
+    port: 3000
 # Read-only Kubernetes MCP server. Single toggle — RBAC, role rules,
 # and bindings are all configured through the upstream subchart's
 # `rbac.extra*` arrays below.


### PR DESCRIPTION
## Summary
- add the Gotenberg Helm chart as an optional `galoy-deps` dependency
- keep Gotenberg disabled by default for existing `galoy-deps` releases
- set singleton-friendly defaults: `fullnameOverride: gotenberg`, `replicaCount: 1`, service port `3000`

## Validation
- `helm lint charts/galoy-deps --with-subcharts`
- `helm template gotenberg charts/galoy-deps --dependency-update --set cert-manager.enabled=false --set kubemonkey.enabled=false --set ingress-nginx.enabled=false --set opentelemetry-collector.enabled=false --set kubernetesMcp.enabled=false --set gotenberg.enabled=true`