### PR TITLE
fix(galoy-deps): prestart Gotenberg Chromium

### DIFF
--- a/charts/galoy-deps/values.yaml
+++ b/charts/galoy-deps/values.yaml
@@ -236,6 +236,9 @@ gotenberg:
   replicaCount: 1
   service:
     port: 3000
+  chromium:
+    autoStart: true
+    startTimeout: 60s
 # Read-only Kubernetes MCP server. Single toggle — RBAC, role rules,
 # and bindings are all configured through the upstream subchart's
 # `rbac.extra*` arrays below.


### PR DESCRIPTION
## Summary
- Set the galoy-deps Gotenberg subchart defaults to prestart Chromium.
- Increase Chromium start timeout to 60s.

## Why
Lana agreement PDF generation in staging hit Gotenberg 500s from `/forms/chromium/convert/markdown` with `start pinning proxy: pinning proxy already started`. Restarting the Gotenberg pod cleared the state and the same agreement generation completed, which points to the lazy first-conversion Chromium startup path. Moving this default into the reusable galoy-deps chart avoids environment-specific overrides.

## Verification
- `helm dependency build charts/galoy-deps`
- `helm template test charts/galoy-deps --set gotenberg.enabled=true` renders `--chromium-auto-start` and `--chromium-start-timeout=60s`
- `helm lint charts/galoy-deps`

Supersedes deployment-only PR: https://github.com/GaloyMoney/galoy-deployments/pull/2539