### PR TITLE
chore: add keycloak to galoy-deps chart

### DIFF
--- a/charts/galoy-deps/Chart.lock
+++ b/charts/galoy-deps/Chart.lock
@@ -17,5 +17,8 @@ dependencies:
 - name: kubernetes-mcp-server
   repository: oci://ghcr.io/containers/charts
   version: 0.1.0
-digest: sha256:9a45876c95610b5303c0d94c39c4369e930b0c8777ecd5fedf5a73879cbfe9d5
-generated: "2026-05-15T18:11:49.006286155Z"
+- name: keycloakx
+  repository: https://codecentric.github.io/helm-charts
+  version: 7.1.11
+digest: sha256:7b8a322be8767ac4054798a797a776f88099945872738d8c19618f53b5ed4c07
+generated: "2026-05-18T14:42:09.570590775+05:30"

--- a/charts/galoy-deps/Chart.yaml
+++ b/charts/galoy-deps/Chart.yaml
@@ -45,3 +45,8 @@ dependencies:
     repository: oci://ghcr.io/containers/charts
     version: 0.1.0
     condition: kubernetesMcp.enabled
+  - name: keycloakx
+    repository: https://codecentric.github.io/helm-charts
+    version: 7.1.11
+    alias: keycloak
+    condition: keycloak.enabled

--- a/charts/galoy-deps/values.yaml
+++ b/charts/galoy-deps/values.yaml
@@ -244,6 +244,21 @@ gotenberg:
 # `rbac.extra*` arrays below.
 kubernetesMcp:
   enabled: false
+keycloak:
+  enabled: true
+  statefulsetLabels: {}
+  podLabels: {}
+  http:
+    relativePath: "/"
+  command:
+    - "/opt/keycloak/bin/kc.sh"
+    - "start"
+    - "--http-port=8080"
+    - "--hostname-strict=false"
+  extraEnv: |
+    - name: JAVA_OPTS_APPEND
+      value: >-
+        -Djgroups.dns.query={{ .Release.Name }}-keycloak-headless
 # Values passed through to the upstream kubernetes-mcp-server chart.
 # Only applied when kubernetesMcp.enabled=true (via the condition on
 # the dependency in Chart.yaml).


### PR DESCRIPTION
Adds Keycloak as a disabled-by-default galoy-deps chart dependency so deployments can enable it from galoy-deps values.