### PR TITLE
feat(galoy-deps): add keycloak mcp component

### DIFF
--- a/charts/galoy-deps/Chart.yaml
+++ b/charts/galoy-deps/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.20-dev
+version: 0.10.21-dev
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/galoy-deps/templates/keycloak-mcp-configmap.yaml
+++ b/charts/galoy-deps/templates/keycloak-mcp-configmap.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.keycloakMcp.enabled .Values.keycloakMcp.declaredSnapshot -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keycloak-mcp-declared-snapshot
+  labels:
+    {{- include "galoy-deps.labels" . | nindent 4 }}
+    app.kubernetes.io/component: keycloak-mcp
+data:
+  snapshot.json: |
+    {{- toPrettyJson .Values.keycloakMcp.declaredSnapshot | nindent 4 }}
+{{- end }}

--- a/charts/galoy-deps/templates/keycloak-mcp-deployment.yaml
+++ b/charts/galoy-deps/templates/keycloak-mcp-deployment.yaml
@@ -1,0 +1,86 @@
+{{- if .Values.keycloakMcp.enabled -}}
+{{- if not .Values.keycloakMcp.keycloakBaseUrl }}
+{{- fail "keycloakMcp.keycloakBaseUrl is required when keycloakMcp.enabled=true" }}
+{{- end }}
+{{- if not .Values.keycloakMcp.existingSecret }}
+{{- fail "keycloakMcp.existingSecret is required when keycloakMcp.enabled=true" }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak-mcp
+  labels:
+    {{- include "galoy-deps.labels" . | nindent 4 }}
+    app.kubernetes.io/component: keycloak-mcp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "galoy-deps.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: keycloak-mcp
+  template:
+    metadata:
+      labels:
+        {{- include "galoy-deps.labels" . | nindent 8 }}
+        app.kubernetes.io/component: keycloak-mcp
+    spec:
+      containers:
+        - name: keycloak-mcp
+          {{- if .Values.keycloakMcp.image.digest }}
+          image: "{{ .Values.keycloakMcp.image.repository }}@{{ .Values.keycloakMcp.image.digest }}"
+          {{- else }}
+          image: "{{ .Values.keycloakMcp.image.repository }}:{{ .Values.keycloakMcp.image.tag }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.keycloakMcp.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8000
+          env:
+            - name: KEYCLOAK_BASE_URL
+              value: {{ .Values.keycloakMcp.keycloakBaseUrl | quote }}
+            {{- if .Values.keycloakMcp.tokenRealm }}
+            - name: KEYCLOAK_TOKEN_REALM
+              value: {{ .Values.keycloakMcp.tokenRealm | quote }}
+            {{- end }}
+            - name: KEYCLOAK_CLIENT_ID
+              value: {{ .Values.keycloakMcp.clientId | quote }}
+            - name: KEYCLOAK_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keycloakMcp.existingSecret }}
+                  key: {{ .Values.keycloakMcp.clientSecretKey }}
+            - name: KEYCLOAK_REALMS
+              value: {{ join "," .Values.keycloakMcp.realms | quote }}
+            - name: KEYCLOAK_MCP_BIND
+              value: "0.0.0.0:8000"
+            - name: KEYCLOAK_MCP_MOUNT
+              value: "/mcp"
+            {{- if .Values.keycloakMcp.declaredSnapshot }}
+            - name: KEYCLOAK_DECLARED_SNAPSHOT_FILE
+              value: /etc/keycloak-mcp/snapshot.json
+            {{- end }}
+            - name: RUST_LOG
+              value: "info"
+          {{- if .Values.keycloakMcp.declaredSnapshot }}
+          volumeMounts:
+            - name: declared-snapshot
+              mountPath: /etc/keycloak-mcp
+              readOnly: true
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          resources:
+            {{- toYaml .Values.keycloakMcp.resources | nindent 12 }}
+      {{- if .Values.keycloakMcp.declaredSnapshot }}
+      volumes:
+        - name: declared-snapshot
+          configMap:
+            name: keycloak-mcp-declared-snapshot
+      {{- end }}
+{{- end }}

--- a/charts/galoy-deps/templates/keycloak-mcp-service.yaml
+++ b/charts/galoy-deps/templates/keycloak-mcp-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.keycloakMcp.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-mcp
+  labels:
+    {{- include "galoy-deps.labels" . | nindent 4 }}
+    app.kubernetes.io/component: keycloak-mcp
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "galoy-deps.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: keycloak-mcp
+  ports:
+    - name: http
+      port: {{ .Values.keycloakMcp.service.port }}
+      targetPort: http
+{{- end }}

--- a/charts/galoy-deps/values.yaml
+++ b/charts/galoy-deps/values.yaml
@@ -244,6 +244,7 @@ gotenberg:
 # `rbac.extra*` arrays below.
 kubernetesMcp:
   enabled: false
+
 keycloak:
   enabled: true
   statefulsetLabels: {}
@@ -259,6 +260,41 @@ keycloak:
     - name: JAVA_OPTS_APPEND
       value: >-
         -Djgroups.dns.query={{ .Release.Name }}-keycloak-headless
+
+keycloakMcp:
+  enabled: false
+  image:
+    repository: us.gcr.io/galoyorg/keycloak-mcp
+    tag: edge
+    digest: ""
+    pullPolicy: IfNotPresent
+  # Internal Keycloak URL, e.g.
+  # http://keycloak-http.galoy-staging-keycloak.svc.cluster.local
+  keycloakBaseUrl: ""
+  # Leave empty to acquire tokens in the target realm. Set only if a
+  # deliberate cross-realm admin client is used.
+  tokenRealm: ""
+  clientId: keycloak-mcp
+  # Existing Secret with the confidential client secret used for
+  # Keycloak Admin REST access.
+  existingSecret: ""
+  clientSecretKey: client-secret
+  realms:
+    - internal
+    - customer
+  # Optional normalized declared snapshot used by diff_declared. Keep
+  # empty until deployment tooling writes a canonical Keycloak snapshot.
+  declaredSnapshot: {}
+  service:
+    port: 8000
+  resources:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+
 # Values passed through to the upstream kubernetes-mcp-server chart.
 # Only applied when kubernetesMcp.enabled=true (via the condition on
 # the dependency in Chart.yaml).


### PR DESCRIPTION
## Summary

Adds a disabled-by-default `keycloakMcp` component to the `galoy-deps` chart.

The component deploys:

- a `keycloak-mcp` Deployment
- a ClusterIP Service on port `8000`
- an optional declared snapshot ConfigMap mounted for `realm_diff_declared`

The chart expects an existing secret containing the Keycloak MCP confidential client secret and points at an internal Keycloak base URL.

## Impact

This lets deployment modules add a Keycloak MCP upstream to the existing Drua tunnel connector without exposing Keycloak directly outside the cluster.

This depends on the `keycloak-mcp` image from GaloyMoney/drua#390.

## Validation

- `helm dependency build charts/galoy-deps`
- `helm lint charts/galoy-deps`
- `helm template test charts/galoy-deps --set keycloakMcp.enabled=true --set keycloakMcp.keycloakBaseUrl=http://keycloak-http.test.svc.cluster.local --set keycloakMcp.existingSecret=keycloak-mcp --set-json 'keycloakMcp.declaredSnapshot={"realms":{"internal":{}}}' --show-only templates/keycloak-mcp-configmap.yaml --show-only templates/keycloak-mcp-deployment.yaml --show-only templates/keycloak-mcp-service.yaml`
