### PR TITLE
fix: fail smoke settings on kubectl errors

### DIFF
--- a/ci/tasks/get-smoketest-settings.sh
+++ b/ci/tasks/get-smoketest-settings.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
 
-set -eu
+set -euo pipefail
 
 mkdir -p .kube
 export KUBECONFIG=$(pwd)/.kube/config
-echo ${SMOKETEST_KUBECONFIG} | base64 --decode > ${KUBECONFIG} || true
+printf '%s' "${SMOKETEST_KUBECONFIG}" | base64 --decode > "${KUBECONFIG}"
 
-kubectl get secret ${SMOKETEST_SECRET:-$(cat testflight/env_name)} -o json \
-  | jq -r '.data' > ${OUT}/data.json
+secret_name="${SMOKETEST_SECRET:-$(cat testflight/env_name)}"
 
-cat <<EOF > ${OUT}/helpers.sh
+kubectl get secret "${secret_name}" -o json \
+  | jq -r '.data' > "${OUT}/data.json"
+
+cat <<EOF > "${OUT}/helpers.sh"
 function setting() {
   cat smoketest-settings/data.json | jq -r ".\$1" | base64 --decode
 }


### PR DESCRIPTION
## Summary
- enable pipefail in the smoke-test settings task
- stop ignoring kubeconfig decode failures
- quote kubeconfig, output, and secret-name arguments

## Verification
- bash -n ci/tasks/get-smoketest-settings.sh
- stubbed kubectl failure exits nonzero
- stubbed kubectl success writes data.json and helpers.sh