### PR TITLE
chore(deps): update helm chart dependencies

### DIFF
--- a/charts/galoy-deps/Chart.lock
+++ b/charts/galoy-deps/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.19.1
+  version: v1.20.2
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
   version: 4.15.1
@@ -10,7 +10,7 @@ dependencies:
   version: 1.5.2
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.156.0
+  version: 0.156.2
 - name: gotenberg
   repository: https://maikumori.github.io/helm-charts/
   version: 1.21.0
@@ -20,5 +20,5 @@ dependencies:
 - name: keycloakx
   repository: https://codecentric.github.io/helm-charts
   version: 7.1.11
-digest: sha256:7b8a322be8767ac4054798a797a776f88099945872738d8c19618f53b5ed4c07
-generated: "2026-05-18T14:42:09.570590775+05:30"
+digest: sha256:84cf1a4c3d0cb586f780f49c7a9cc1927218d5f9b3199c528f2b06121279b4e5
+generated: "2026-05-25T18:18:36.980824+02:00"

--- a/charts/galoy-deps/Chart.yaml
+++ b/charts/galoy-deps/Chart.yaml
@@ -22,7 +22,7 @@ appVersion: "0.1.0"
 dependencies:
   - name: "cert-manager"
     repository: "https://charts.jetstack.io"
-    version: v1.19.1
+    version: v1.20.2
     condition: cert-manager.enabled
   - name: "ingress-nginx"
     repository: "https://kubernetes.github.io/ingress-nginx"
@@ -35,7 +35,7 @@ dependencies:
     condition: kubemonkey.enabled
   - name: opentelemetry-collector
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-    version: 0.156.0
+    version: 0.156.2
     condition: opentelemetry-collector.enabled
   - name: gotenberg
     repository: https://maikumori.github.io/helm-charts/


### PR DESCRIPTION
Updates Helm chart dependencies in `galoy-deps`:\n\n- cert-manager: `v1.19.1` -> `v1.20.2`\n- opentelemetry-collector: `0.156.0` -> `0.156.2`\n\nRegenerated `charts/galoy-deps/Chart.lock` with Helm.\n\nValidation:\n- `helm lint charts/galoy-deps`\n- `helm dependency list charts/galoy-deps`