### PR TITLE
fix: clean up galoy-deps testflight on smoke failures

### DIFF
--- a/ci/pipeline-fragments.lib.yml
+++ b/ci/pipeline-fragments.lib.yml
@@ -45,54 +45,56 @@ plan:
       CHART: #@ chart
     run:
       path: pipeline-tasks/ci/tasks/prepare-testflight.sh
-- put: #@ "tf-" + chart + "-testflight"
-  tags:
-    - #@ data.values.staging_worker_tag
-  params:
-    vars_files: [ testflight/tf/terraform.tfvars ]
-    terraform_source: testflight/tf
-    env_name_file: testflight/env_name
-    vars: #@ vars
-- task: get-smoketest-settings
-  tags:
-    - #@ data.values.staging_worker_tag
-  config:
-    platform: linux
-    image_resource: #@ task_image_config()
-    inputs:
-    - name: #@ chart_resource_name(chart)
-      path: pipeline-tasks
-    - name: testflight
-    outputs:
-    - name: smoketest-settings
+- do:
+  - put: #@ "tf-" + chart + "-testflight"
+    tags:
+      - #@ data.values.staging_worker_tag
     params:
-      SMOKETEST_KUBECONFIG: #@ data.values.staging_smoketest_kubeconfig
-      OUT: smoketest-settings
-    run:
-      path: pipeline-tasks/ci/tasks/get-smoketest-settings.sh
-- task: smoketest
-  tags:
-    - #@ data.values.staging_worker_tag
-  config:
-    platform: linux
-    image_resource: #@ task_image_config()
-    inputs:
-    - name: #@ chart_resource_name(chart)
-      path: pipeline-tasks
-    - name: smoketest-settings
+      vars_files: [ testflight/tf/terraform.tfvars ]
+      terraform_source: testflight/tf
+      env_name_file: testflight/env_name
+      vars: #@ vars
+  - task: get-smoketest-settings
+    tags:
+      - #@ data.values.staging_worker_tag
+    config:
+      platform: linux
+      image_resource: #@ task_image_config()
+      inputs:
+      - name: #@ chart_resource_name(chart)
+        path: pipeline-tasks
+      - name: testflight
+      outputs:
+      - name: smoketest-settings
+      params:
+        SMOKETEST_KUBECONFIG: #@ data.values.staging_smoketest_kubeconfig
+        OUT: smoketest-settings
+      run:
+        path: pipeline-tasks/ci/tasks/get-smoketest-settings.sh
+  - task: smoketest
+    tags:
+      - #@ data.values.staging_worker_tag
+    config:
+      platform: linux
+      image_resource: #@ task_image_config()
+      inputs:
+      - name: #@ chart_resource_name(chart)
+        path: pipeline-tasks
+      - name: smoketest-settings
+      params:
+      run:
+        path: #@ "pipeline-tasks/ci/tasks/" + chart + "-smoketest.sh"
+  ensure:
+    put: #@ "tf-" + chart + "-testflight"
+    tags:
+      - #@ data.values.staging_worker_tag
     params:
-    run:
-      path: #@ "pipeline-tasks/ci/tasks/" + chart + "-smoketest.sh"
-- put: #@ "tf-" + chart + "-testflight"
-  tags:
-    - #@ data.values.staging_worker_tag
-  params:
-    vars_files: [ testflight/tf/terraform.tfvars ]
-    terraform_source: testflight/tf
-    env_name_file: testflight/env_name
-    action: destroy
-    vars: #@ vars
-  get_params: { action: destroy }
+      vars_files: [ testflight/tf/terraform.tfvars ]
+      terraform_source: testflight/tf
+      env_name_file: testflight/env_name
+      action: destroy
+      vars: #@ vars
+    get_params: { action: destroy }
 #@ end
 
 #@ def bump_in_deployments_job(chart):

--- a/ci/testflight/galoy-deps/main.tf
+++ b/ci/testflight/galoy-deps/main.tf
@@ -8,6 +8,8 @@ locals {
   testflight_namespace         = var.testflight_namespace
   service_name                 = "${local.testflight_namespace}-ingress"
   jaeger_host                  = "galoy-deps-opentelemetry-collector"
+  cert_manager_fullname        = "${local.testflight_namespace}-cert-manager"
+  ingress_nginx_fullname       = "${local.testflight_namespace}-ingress-nginx"
   kubemonkey_fullname_override = local.testflight_namespace
 }
 
@@ -26,6 +28,8 @@ resource "helm_release" "galoy_deps" {
     templatefile("${path.module}/testflight-values.yml.tmpl", {
       service_name : local.service_name
       jaeger_host : local.jaeger_host
+      cert_manager_fullname : local.cert_manager_fullname
+      ingress_nginx_fullname : local.ingress_nginx_fullname
       kubemonkey_fullname_override : local.kubemonkey_fullname_override
     })
   ]

--- a/ci/testflight/galoy-deps/testflight-values.yml.tmpl
+++ b/ci/testflight/galoy-deps/testflight-values.yml.tmpl
@@ -1,9 +1,11 @@
 kubemonkey:
   fullnameOverride: ${kubemonkey_fullname_override}
 cert-manager:
+  fullnameOverride: ${cert_manager_fullname}
   crds:
    enabled: false
 ingress-nginx:
+  fullnameOverride: ${ingress_nginx_fullname}
   controller:
     ingressClassResource:
       enabled: false


### PR DESCRIPTION
## Summary
- give galoy-deps testflight cert-manager and ingress-nginx unique fullname overrides derived from the smoke namespace
- run Terraform destroy from a Concourse ensure block so failed smoke setup does not leak testflight resources

## Verification
- helm lint charts/galoy-deps with testflight overrides
- ytt -f ci/pipeline.yml -f ci/pipeline-fragments.lib.yml -f ci/values.yml --data-values-env YTT