### PR TITLE
chore(galoy-deps): remove ingress-nginx

### DIFF
--- a/charts/galoy-deps/Chart.lock
+++ b/charts/galoy-deps/Chart.lock
@@ -2,9 +2,6 @@ dependencies:
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.20.2
-- name: ingress-nginx
-  repository: https://kubernetes.github.io/ingress-nginx
-  version: 4.15.1
 - name: traefik
   repository: https://traefik.github.io/charts
   version: 40.2.0
@@ -23,5 +20,5 @@ dependencies:
 - name: keycloakx
   repository: https://codecentric.github.io/helm-charts
   version: 7.2.0
-digest: sha256:ecdbab668ad0e7075ee7fd8ec8c16a0743e1a9534ddcbddbc8a60501072dbf8d
-generated: "2026-05-26T09:25:53.138750983Z"
+digest: sha256:ec0a0262ff7c68b1a958dd662988f8ce4bea8561bb3b423e4528052c9e118f9f
+generated: "2026-05-27T18:27:19.615798183+05:30"

--- a/charts/galoy-deps/Chart.yaml
+++ b/charts/galoy-deps/Chart.yaml
@@ -24,10 +24,6 @@ dependencies:
     repository: "https://charts.jetstack.io"
     version: v1.20.2
     condition: cert-manager.enabled
-  - name: "ingress-nginx"
-    repository: "https://kubernetes.github.io/ingress-nginx"
-    version: 4.15.1
-    condition: ingress-nginx.enabled
   - name: "traefik"
     repository: "https://traefik.github.io/charts"
     version: 40.2.0

--- a/charts/galoy-deps/values.yaml
+++ b/charts/galoy-deps/values.yaml
@@ -208,30 +208,7 @@ cert-manager:
   crds:
     enabled: true
   resources: {}
-ingress-nginx:
-  enabled: true
-  controller:
-    allowSnippetAnnotations: true
-    resources: {}
-    ingressClassResource:
-      default: true
-      watchIngressWithoutClass: true
-    config:
-      enable-opentelemetry: true
-      annotations-risk-level: "Critical"
-      log-format-upstream: "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" $request_length $request_time [$proxy_upstream_name] [$proxy_alternative_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status $req_id"
-    service:
-      externalTrafficPolicy: Local
-      # service type should be NodePort when deploying locally
-      type: LoadBalancer
-    metrics:
-      enabled: true
-      service:
-        annotations:
-          prometheus.io/scrape: "true"
-          prometheus.io/port: "10254"
 traefik:
-  enabled: false
   fullnameOverride: traefik
   gateway:
     enabled: false

--- a/ci/testflight/galoy-deps/testflight-values.yml.tmpl
+++ b/ci/testflight/galoy-deps/testflight-values.yml.tmpl
@@ -3,15 +3,6 @@ kubemonkey:
 cert-manager:
   crds:
    enabled: false
-ingress-nginx:
-  controller:
-    ingressClassResource:
-      enabled: false
-    config:
-      jaeger-service-name: ${service_name}
-      jaeger-collector-host: ${jaeger_host}
-traefik:
-  enabled: false
 opentelemetry-collector:
   clusterRole:
     create: false


### PR DESCRIPTION
Removes the ingress-nginx dependency and default values from the galoy-deps chart. Traefik is now the only ingress controller dependency enabled by default.

Validation:
- `nix develop -c helm dependency update charts/galoy-deps`
- `nix develop -c helm lint charts/galoy-deps`
- `nix develop -c helm template galoy-deps charts/galoy-deps`
