### PR TITLE
fix(galoy-deps): allow mcp to read traefik middlewares

### DIFF
--- a/charts/galoy-deps/values.yaml
+++ b/charts/galoy-deps/values.yaml
@@ -308,6 +308,12 @@ kubernetes-mcp-server:
             resources:
               - ingresses
             verbs: ["get", "list", "watch"]
+          # Traefik CRDs — needed to inspect middleware wiring such as
+          # rateLimit and inFlightReq attached to ingress routers.
+          - apiGroups: ["traefik.io"]
+            resources:
+              - middlewares
+            verbs: ["get", "list", "watch"]
           # Newer events API (Kubernetes 1.19+). The core `""`.events
           # entry above covers the legacy shape; some components emit
           # only to this group.


### PR DESCRIPTION
## Summary
- allow the kubernetes MCP server to read Traefik Middleware CRDs
- keep access scoped to `traefik.io` `middlewares` with read-only verbs

## Test
- `helm template` rendered the rule into the MCP ClusterRole
- `helm lint` passed