### PR TITLE
fix(galoy-deps): avoid traefik cluster resources in testflight

### DIFF
--- a/ci/testflight/galoy-deps/testflight-values.yml.tmpl
+++ b/ci/testflight/galoy-deps/testflight-values.yml.tmpl
@@ -3,6 +3,11 @@ kubemonkey:
 cert-manager:
   crds:
    enabled: false
+traefik:
+  ingressClass:
+    enabled: false
+  rbac:
+    namespaced: true
 opentelemetry-collector:
   clusterRole:
     create: false


### PR DESCRIPTION
## Summary
- disable Traefik IngressClass creation in galoy-deps testflight
- use namespaced Traefik RBAC for testflight so it does not claim cluster-scoped Traefik resources

## Validation
- helm template: no IngressClass, no Traefik ClusterRole, no Traefik ClusterRoleBinding
- tofu -chdir=ci/testflight/galoy-deps validate