### PR TITLE
fix(ci): use tofu resource image

### DIFF
--- a/ci/pipeline-fragments.lib.yml
+++ b/ci/pipeline-fragments.lib.yml
@@ -115,7 +115,7 @@ source:
 
 #@ def testflight_tf_resource(chart_name):
 name: #@ "tf-" + chart_name + "-testflight"
-type: terraform
+type: tofu
 source:
   backend_type: gcs
   backend_config:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -42,7 +42,7 @@ resources:
     private_key: #@ data.values.github_private_key
 
 resource_types:
-- name: terraform
+- name: tofu
   type: registry-image
   source:
     repository: #@ data.values.docker_registry + "/tofu-resource"

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -45,7 +45,7 @@ resource_types:
 - name: terraform
   type: registry-image
   source:
-    repository: #@ data.values.docker_registry + "/terraform-resource"
+    repository: #@ data.values.docker_registry + "/tofu-resource"
     tag: latest
     username: #@ data.values.gar_registry_user
     password: #@ data.values.gar_registry_password


### PR DESCRIPTION
## Summary
- switch the chart testflight `terraform` resource type to `us.gcr.io/galoyorg/tofu-resource`

## Verification
- `ytt -f ci >/tmp/galoy-charts-pipeline.yml`
- confirmed rendered resource type points at `us.gcr.io/galoyorg/tofu-resource`

Note: `fly validate-pipeline` still fails on the pre-existing unused `charts-repo` resource, unrelated to this change.

Related: GaloyMoney/galoy-org-infra#109