### PR TITLE
feat: add galoy gitops chart

### DIFF
--- a/charts/galoy-gitops/.helmignore
+++ b/charts/galoy-gitops/.helmignore
@@ -1,0 +1,3 @@
+.git/
+.gitignore
+.DS_Store

--- a/charts/galoy-gitops/Chart.lock
+++ b/charts/galoy-gitops/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: argo-cd
+  repository: https://argoproj.github.io/argo-helm
+  version: 9.5.17
+- name: crossplane
+  repository: https://charts.crossplane.io/stable
+  version: 2.3.1
+digest: sha256:fd24f660c807c42a8a1ace5ba92d07bb20b6ef780bfdc35a377c10d9ca834204
+generated: "2026-06-01T18:45:38.227635+02:00"

--- a/charts/galoy-gitops/Chart.yaml
+++ b/charts/galoy-gitops/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: galoy-gitops
+description: Galoy GitOps control-plane dependencies
+type: application
+version: 0.1.0-dev
+appVersion: "0.1.0"
+dependencies:
+  - name: argo-cd
+    repository: https://argoproj.github.io/argo-helm
+    version: 9.5.17
+  - name: crossplane
+    repository: https://charts.crossplane.io/stable
+    version: 2.3.1

--- a/charts/galoy-gitops/README.md
+++ b/charts/galoy-gitops/README.md
@@ -1,0 +1,9 @@
+# galoy-gitops
+
+Umbrella Helm chart for the Galoy GitOps control plane.
+
+This chart installs:
+
+- Argo CD, including the ApplicationSet controller
+- Crossplane
+


### PR DESCRIPTION
## Summary\n- add a galoy-gitops umbrella chart for Argo CD and Crossplane\n- pin argo-cd 9.5.17 and crossplane 2.3.1\n- include default values for an internal GitOps control plane\n\n## Validation\n- nix develop --command helm dependency update charts/galoy-gitops\n- nix develop --command helm lint charts/galoy-gitops\n- nix develop --command helm template galoy-gitops charts/galoy-gitops