### PR TITLE
ci: add galoy gitops chart pipeline

### DIFF
--- a/ci/pipeline-fragments.lib.yml
+++ b/ci/pipeline-fragments.lib.yml
@@ -16,6 +16,10 @@ source:
 #@  return chart + "-testflight"
 #@ end
 
+#@ def lint_job_name(chart):
+#@  return chart + "-lint"
+#@ end
+
 #@ def bump_in_deployments_job_name(chart):
 #@  return "bump-" + chart + "-in-deployments"
 #@ end
@@ -65,13 +69,39 @@ plan:
   get_params: { action: destroy }
 #@ end
 
-#@ def bump_in_deployments_job(chart):
+#@ def lint_job(chart):
+name: #@ lint_job_name(chart)
+plan:
+- in_parallel:
+  - get: #@ chart_resource_name(chart)
+    trigger: true
+  - { get: pipeline-tasks }
+- task: helm-lint
+  config:
+    platform: linux
+    image_resource: #@ task_image_config()
+    inputs:
+    - name: #@ chart_resource_name(chart)
+      path: repo
+    params:
+      CHART: #@ chart
+    run:
+      path: sh
+      args:
+      - -ceu
+      - |
+        helm dependency update "repo/charts/${CHART}"
+        helm lint "repo/charts/${CHART}"
+#@ end
+
+#@ def bump_in_deployments_job(chart, passed_job = ""):
+#@ passed = passed_job if passed_job != "" else testflight_job_name(chart)
 name: #@ "bump-" + chart + "-in-deployments"
 plan:
 - in_parallel:
   - get: #@ chart_resource_name(chart)
     passed:
-    - #@ testflight_job_name(chart)
+    - #@ passed
     trigger: true
   - { get: pipeline-tasks }
   - { get: galoy-deployments }

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,6 +1,8 @@
 #@ load("@ytt:data", "data")
 #@ load("pipeline-fragments.lib.yml",
 #@   "testflight_job",
+#@   "lint_job",
+#@   "lint_job_name",
 #@   "bump_in_deployments_job",
 #@   "chart_repo_resource",
 #@   "testflight_tf_resource")
@@ -10,13 +12,20 @@ groups:
   jobs:
   - galoy-deps-testflight
   - bump-galoy-deps-in-deployments
+- name: galoy-gitops
+  jobs:
+  - galoy-gitops-lint
+  - bump-galoy-gitops-in-deployments
 
 jobs:
 - #@ testflight_job("galoy-deps", "galoy-deps")
 - #@ bump_in_deployments_job("galoy-deps")
+- #@ lint_job("galoy-gitops")
+- #@ bump_in_deployments_job("galoy-gitops", lint_job_name("galoy-gitops"))
 
 resources:
 - #@ chart_repo_resource("galoy-deps")
+- #@ chart_repo_resource("galoy-gitops")
 - #@ testflight_tf_resource("galoy-deps")
 
 - name: charts-repo


### PR DESCRIPTION
## Summary\n- add a galoy-gitops chart pipeline group\n- lint galoy-gitops chart changes before bumping galoy-deployments\n- reuse the existing bump-in-deployments flow with a configurable prerequisite job\n\n## Notes\n- galoy-gitops is a control-plane chart with cluster-scoped resources, so this starts with Helm lint rather than the ephemeral staging testflight install used by galoy-deps.\n- This should merge after the galoy-deployments vendir import, because the bump job expects galoy_gitops_git_ref in vendir/values.yml.\n\n## Validation\n- ytt -f ci\n- nix develop --command helm dependency update charts/galoy-gitops\n- nix develop --command helm lint charts/galoy-gitops