### PR TITLE
feat(galoy-deps): add Lana Postgres MCP wiring

### DIFF
--- a/charts/galoy-deps/templates/_helpers.tpl
+++ b/charts/galoy-deps/templates/_helpers.tpl
@@ -75,3 +75,25 @@ via its `--upstreams` / `TUNNEL_UPSTREAMS` arg.
 {{- end -}}
 {{- join "," $parts -}}
 {{- end }}
+
+{{/*
+Create the ServiceAccount name for tunnel-connector.
+*/}}
+{{- define "galoy-deps.tunnelConnector.serviceAccountName" -}}
+{{- if .Values.tunnelConnector.serviceAccount.create }}
+{{- default "tunnel-connector" .Values.tunnelConnector.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.tunnelConnector.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Render the DBHub image used by tunnelConnector.postgresMcp.
+*/}}
+{{- define "galoy-deps.tunnelConnector.postgresMcp.image" -}}
+{{- if .Values.tunnelConnector.postgresMcp.image.digest -}}
+{{ .Values.tunnelConnector.postgresMcp.image.repository }}@{{ .Values.tunnelConnector.postgresMcp.image.digest }}
+{{- else -}}
+{{ .Values.tunnelConnector.postgresMcp.image.repository }}:{{ .Values.tunnelConnector.postgresMcp.image.tag }}
+{{- end -}}
+{{- end }}

--- a/charts/galoy-deps/templates/tunnel-connector-deployment.yaml
+++ b/charts/galoy-deps/templates/tunnel-connector-deployment.yaml
@@ -8,8 +8,8 @@
 {{- if not .Values.tunnelConnector.existingPrivateKeySecret }}
 {{- fail "tunnelConnector.existingPrivateKeySecret is required when tunnelConnector.enabled=true" }}
 {{- end }}
-{{- if not .Values.tunnelConnector.upstreams }}
-{{- fail "tunnelConnector.upstreams must list at least one {name, url} entry" }}
+{{- if and (not .Values.tunnelConnector.upstreams) (not .Values.tunnelConnector.postgresMcp.enabled) }}
+{{- fail "tunnelConnector.upstreams must list at least one {name, url} entry unless tunnelConnector.postgresMcp.enabled=true" }}
 {{- end }}
 apiVersion: apps/v1
 kind: Deployment
@@ -30,6 +30,9 @@ spec:
         {{- include "galoy-deps.labels" . | nindent 8 }}
         app.kubernetes.io/component: tunnel-connector
     spec:
+      {{- if or .Values.tunnelConnector.postgresMcp.enabled .Values.tunnelConnector.serviceAccount.name }}
+      serviceAccountName: {{ include "galoy-deps.tunnelConnector.serviceAccountName" . }}
+      {{- end }}
       containers:
         - name: connector
           {{- /*
@@ -52,6 +55,49 @@ spec:
               value: {{ include "galoy-deps.tunnelConnector.upstreamsEnv" . | quote }}
             - name: TUNNEL_PRIVATE_KEY_FILE
               value: /var/run/secrets/tunnel-connector/private_key.pem
+            {{- if .Values.tunnelConnector.postgresMcp.enabled }}
+            - name: TUNNEL_POSTGRES_MCP_ENABLED
+              value: "true"
+            {{- if .Values.tunnelConnector.postgresMcp.namespace }}
+            - name: TUNNEL_POSTGRES_MCP_NAMESPACE
+              value: {{ .Values.tunnelConnector.postgresMcp.namespace | quote }}
+            {{- else }}
+            - name: TUNNEL_POSTGRES_MCP_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- end }}
+            - name: TUNNEL_POSTGRES_MCP_REGISTRY_SECRET
+              value: {{ .Values.tunnelConnector.postgresMcp.registrySecretName | quote }}
+            - name: TUNNEL_POSTGRES_MCP_REGISTRY_KEY
+              value: {{ .Values.tunnelConnector.postgresMcp.registryKey | quote }}
+            - name: TUNNEL_POSTGRES_MCP_RESOURCE_NAME
+              value: {{ .Values.tunnelConnector.postgresMcp.resourceName | quote }}
+            - name: TUNNEL_POSTGRES_MCP_CONFIG_SECRET
+              value: {{ .Values.tunnelConnector.postgresMcp.configSecretName | quote }}
+            - name: TUNNEL_POSTGRES_MCP_UPSTREAM_NAME
+              value: {{ .Values.tunnelConnector.postgresMcp.upstreamName | quote }}
+            - name: TUNNEL_POSTGRES_MCP_IMAGE
+              value: {{ include "galoy-deps.tunnelConnector.postgresMcp.image" . | quote }}
+            - name: TUNNEL_POSTGRES_MCP_IMAGE_PULL_POLICY
+              value: {{ .Values.tunnelConnector.postgresMcp.image.pullPolicy | quote }}
+            - name: TUNNEL_POSTGRES_MCP_SERVICE_PORT
+              value: {{ .Values.tunnelConnector.postgresMcp.service.port | quote }}
+            - name: TUNNEL_POSTGRES_MCP_QUERY_TIMEOUT
+              value: {{ .Values.tunnelConnector.postgresMcp.queryTimeout | quote }}
+            - name: TUNNEL_POSTGRES_MCP_MAX_ROWS
+              value: {{ .Values.tunnelConnector.postgresMcp.maxRows | quote }}
+            - name: TUNNEL_POSTGRES_MCP_CONNECT_TIMEOUT_SECS
+              value: {{ .Values.tunnelConnector.postgresMcp.connectTimeoutSeconds | quote }}
+            - name: TUNNEL_POSTGRES_MCP_REQUEST_CPU
+              value: {{ .Values.tunnelConnector.postgresMcp.resources.requests.cpu | quote }}
+            - name: TUNNEL_POSTGRES_MCP_REQUEST_MEMORY
+              value: {{ .Values.tunnelConnector.postgresMcp.resources.requests.memory | quote }}
+            - name: TUNNEL_POSTGRES_MCP_LIMIT_CPU
+              value: {{ .Values.tunnelConnector.postgresMcp.resources.limits.cpu | quote }}
+            - name: TUNNEL_POSTGRES_MCP_LIMIT_MEMORY
+              value: {{ .Values.tunnelConnector.postgresMcp.resources.limits.memory | quote }}
+            {{- end }}
             - name: RUST_LOG
               value: "info"
           volumeMounts:

--- a/charts/galoy-deps/templates/tunnel-connector-rbac.yaml
+++ b/charts/galoy-deps/templates/tunnel-connector-rbac.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.tunnelConnector.enabled -}}
+{{- $needsServiceAccount := or .Values.tunnelConnector.postgresMcp.enabled .Values.tunnelConnector.serviceAccount.name -}}
+{{- if and .Values.tunnelConnector.serviceAccount.create $needsServiceAccount }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "galoy-deps.tunnelConnector.serviceAccountName" . }}
+  labels:
+    {{- include "galoy-deps.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tunnel-connector
+{{- end }}
+{{- if .Values.tunnelConnector.postgresMcp.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tunnel-connector-postgres-mcp
+  labels:
+    {{- include "galoy-deps.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tunnel-connector
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - {{ .Values.tunnelConnector.postgresMcp.registrySecretName | quote }}
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - {{ .Values.tunnelConnector.postgresMcp.configSecretName | quote }}
+    verbs: ["get", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["services"]
+    resourceNames:
+      - {{ .Values.tunnelConnector.postgresMcp.resourceName | quote }}
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["create"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames:
+      - {{ .Values.tunnelConnector.postgresMcp.resourceName | quote }}
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tunnel-connector-postgres-mcp
+  labels:
+    {{- include "galoy-deps.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tunnel-connector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tunnel-connector-postgres-mcp
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "galoy-deps.tunnelConnector.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/charts/galoy-deps/values.yaml
+++ b/charts/galoy-deps/values.yaml
@@ -400,6 +400,39 @@ tunnelConnector:
   upstreams:
     - name: k8s
       url: http://kubernetes-mcp-server:8080/mcp
+  serviceAccount:
+    create: true
+    name: ""
+  postgresMcp:
+    enabled: false
+    # Defaults to the tunnel connector pod namespace when empty.
+    namespace: ""
+    # Lana writes this Secret. The connector only reads it.
+    registrySecretName: lana-postgres-mcp-registry
+    registryKey: registry.yaml
+    # Fixed generated aggregate DBHub resources owned by tunnel-connector.
+    resourceName: lana-postgres-mcp
+    configSecretName: lana-postgres-mcp-config
+    # Drua upstream name. Tool names become:
+    # <deployment>_lana_postgres_execute_sql_<instance>_<runtime|datawarehouse>
+    upstreamName: lana_postgres
+    image:
+      repository: bytebase/dbhub
+      tag: 0.21.1
+      digest: ""
+      pullPolicy: IfNotPresent
+    service:
+      port: 8000
+    queryTimeout: 30
+    maxRows: 1000
+    connectTimeoutSeconds: 5
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
   replicas: 1
   resources:
     requests:


### PR DESCRIPTION
## What changed

- Adds disabled-by-default `tunnelConnector.postgresMcp` chart values.
- Wires the Postgres MCP env vars into tunnel-connector.
- Adds tunnel-connector ServiceAccount and namespace RBAC for reading the Lana registry Secret and applying generated DBHub Secret, Service, and Deployment resources.
- Allows an empty static upstream list when Postgres MCP is enabled.

## Why

This gives galoy-deps the Helm-owned lifecycle machinery needed for tunnel-connector to own DBHub wiring, while keeping the feature off until deployments cut over.

## Validation

- nix develop /home/sandipndev/projects/galoy-charts -c helm lint charts/galoy-deps --set tunnelConnector.enabled=true --set tunnelConnector.serverUrl=wss://example.invalid/tunnel/ws --set tunnelConnector.deploymentId=test --set tunnelConnector.existingPrivateKeySecret=tunnel-key --set tunnelConnector.postgresMcp.enabled=true --set-json tunnelConnector.upstreams=[]
- nix develop /home/sandipndev/projects/galoy-charts -c helm template test charts/galoy-deps --dependency-update --set tunnelConnector.enabled=true --set tunnelConnector.serverUrl=wss://example.invalid/tunnel/ws --set tunnelConnector.deploymentId=test --set tunnelConnector.existingPrivateKeySecret=tunnel-key --set tunnelConnector.postgresMcp.enabled=true --set-json tunnelConnector.upstreams=[]
- git diff --check
